### PR TITLE
Only register Enter key when one item is selected

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -500,8 +500,8 @@ const NavigatorCardBody = ({
 
                     return [sortedFiles[newIdx]];
                 });
-            } else if (e.key === "Enter") {
-                onDoubleClickNavigate(selected?.[0]);
+            } else if (e.key === "Enter" && selected.length === 1) {
+                onDoubleClickNavigate(selected[0]);
             }
         };
 


### PR DESCRIPTION
Fixes 2 issues:
1. If multiple items are selected, Enter would navigate into last selected item if it's a folder
2. De-selecting an item and hitting Enter caused an error