### PR TITLE
Improve layout in several ways

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -293,27 +293,6 @@ export const Application = () => {
             }}
             >
                 <Sidebar isPanelRight hasGutter>
-                    <SidebarPanel className="sidebar-panel" width={{ default: "width_25" }}>
-                        <SidebarPanelDetails
-                          path={path}
-                          selected={selected.map(s => files.find(f => f.name === s.name)).filter(s => s !== undefined)}
-                          currentDirectory={
-                              {
-                                  has_error: errorMessage,
-                                  name: path[path.length - 1],
-                                  items_cnt: {
-                                      all: files.length,
-                                      hidden: files.length - files.filter(file => !file.name.startsWith(".")).length
-                                  }
-                              }
-                          }
-                          setHistory={setHistory} setHistoryIndex={setHistoryIndex}
-                          showHidden={showHidden} setSelected={setSelected}
-                          setShowHidden={setShowHidden}
-                          clipboard={clipboard} setClipboard={setClipboard}
-                          files={files} addAlert={addAlert}
-                        />
-                    </SidebarPanel>
                     <SidebarContent>
                         <Card>
                             <NavigatorCardHeader
@@ -355,6 +334,27 @@ export const Application = () => {
                             </AlertGroup>
                         </Card>
                     </SidebarContent>
+                    <SidebarPanel className="sidebar-panel" width={{ default: "width_25" }}>
+                        <SidebarPanelDetails
+                          path={path}
+                          selected={selected.map(s => files.find(f => f.name === s.name)).filter(s => s !== undefined)}
+                          currentDirectory={
+                              {
+                                  has_error: errorMessage,
+                                  name: path[path.length - 1],
+                                  items_cnt: {
+                                      all: files.length,
+                                      hidden: files.length - files.filter(file => !file.name.startsWith(".")).length
+                                  }
+                              }
+                          }
+                          setHistory={setHistory} setHistoryIndex={setHistoryIndex}
+                          showHidden={showHidden} setSelected={setSelected}
+                          setShowHidden={setShowHidden}
+                          clipboard={clipboard} setClipboard={setClipboard}
+                          files={files} addAlert={addAlert}
+                        />
+                    </SidebarPanel>
                 </Sidebar>
             </PageSection>
         </Page>

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -23,12 +23,13 @@ import { useDialogs } from "dialogs.jsx";
 import React, { useCallback, useEffect, useMemo, useState, useRef } from "react";
 import {
     Card, CardBody,
-    Flex, FlexItem,
+    Flex,
+    Gallery,
     Icon,
     MenuItem, MenuList,
     Page, PageSection,
-    Sidebar, SidebarPanel, SidebarContent, Truncate,
-    CardHeader, CardTitle, Divider, AlertGroup, Alert, AlertActionCloseButton, Spinner
+    Sidebar, SidebarPanel, SidebarContent,
+    CardTitle, Divider, AlertGroup, Alert, AlertActionCloseButton, Spinner, CardHeader,
 } from "@patternfly/react-core";
 import { ExclamationCircleIcon, FileIcon, FolderIcon } from "@patternfly/react-icons";
 
@@ -556,7 +557,7 @@ const NavigatorCardBody = ({
               data-item={file.name}
               id={"card-item-" + file.name + file.type}
               isClickable isCompact
-              isPlain isRounded
+              isPlain
               isSelected={selected.find(s => s.name === file.name)}
               onClick={ev => handleClick(ev, file)}
               onContextMenu={(e) => {
@@ -574,38 +575,17 @@ const NavigatorCardBody = ({
                       selectableActionId: "card-item-" + file.name + file.type + "-selectable-action",
                   }}
                 >
+                    <Icon
+                      size={isGrid
+                          ? "xl"
+                          : "lg"} isInline
+                    >
+                        {file.type === "directory" || file.to === "directory"
+                            ? <FolderIcon />
+                            : <FileIcon />}
+                    </Icon>
                     <CardTitle>
-                        <Flex
-                          direction={{
-                              default: isGrid
-                                  ? "column"
-                                  : "row"
-                          }} spaceItems={{
-                              default: isGrid
-                                  ? "spaceItemsNone"
-                                  : "spaceItemsMd"
-                          }}
-                        >
-                            <FlexItem alignSelf={{ default: "alignSelfCenter" }}>
-                                <Icon
-                                  size={isGrid
-                                      ? "xl"
-                                      : "lg"} isInline
-                                >
-                                    {file.type === "directory" || file.to === "directory"
-                                        ? <FolderIcon />
-                                        : <FileIcon />}
-                                </Icon>
-                            </FlexItem>
-                            <FlexItem className={"pf-u-text-break-word pf-u-text-wrap" + (isGrid
-                                ? " grid-file-name"
-                                : "")}
-                            >
-                                {selected?.name !== file.name
-                                    ? <Truncate content={file.name} position="middle" />
-                                    : file.name}
-                            </FlexItem>
-                        </Flex>
+                        {file.name}
                     </CardTitle>
                 </CardHeader>
             </Card>
@@ -621,9 +601,9 @@ const NavigatorCardBody = ({
     if (isGrid) {
         return (
             <CardBody onClick={resetSelected} id="navigator-card-body">
-                <Flex id="folder-view">
+                <Gallery id="folder-view">
                     {sortedFiles.map(file => <Item file={file} key={file.name} />)}
-                </Flex>
+                </Gallery>
             </CardBody>
         );
     } else {

--- a/src/app.scss
+++ b/src/app.scss
@@ -30,6 +30,47 @@
     color: var(--pf-global--primary-color--100);
 }
 
+.pf-v5-l-gallery {
+    --pf-v5-l-gallery--GridTemplateColumns--max: 10rem;
+    align-items: start;
+    gap: var(--pf-v5-global--spacer--sm);
+    grid-template-columns: repeat(auto-fill, minmax(var(--pf-v5-l-gallery--GridTemplateColumns--max), 1fr));
+}
+
+.directory-item, .file-item {
+    // Align icon and text in icon mode
+    .pf-v5-l-gallery & .pf-v5-c-card__header-main {
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        gap: 0;
+    }
+
+    // Align icon and text in list mode
+    .ct-table & .pf-v5-c-card__header-main {
+        justify-content: start !important;
+        gap: var(--pf-v5-global--spacer--sm);
+    }
+
+    // Limit to 3 vertical lines and add ellipsis at the end when needed.
+    // (Sadly, there's no way to truncate in the middle, except via a PF
+    // component... but that doesn't allow wrapping and clamping line height.)
+    .pf-v5-c-card__title-text {
+        // Yes, all browsers support line-clamp with the webkit prefix. No
+        // browser supports it unprefixed. All browsers require a display of
+        // -webkit-box and -webkit-box-orient as well. It's one of the few
+        // prefixed attributes that's so well supported and still needed.
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        overflow-wrap: anywhere;
+        // Wrapping should be more balanced (new; not supported everywhere yet)
+        text-wrap: balance;
+    }
+}
+
 .directory-item {
     --icon-color: var(--pf-v5-global--link--Color--light);
 

--- a/src/app.scss
+++ b/src/app.scss
@@ -30,6 +30,22 @@
     color: var(--pf-global--primary-color--100);
 }
 
+// Make the card heading sticky
+.card-actionbar {
+    position: sticky;
+    // Background bleeds through, so we need we need to add a local background
+    background: var(--pf-v5-global--BackgroundColor--100);
+    // Breadcrumb header size + padding?
+    top: calc(var(--pf-v5-global--spacer--md) * 3.5);
+    // Lift up above icon content
+    z-index: 1;
+}
+
+// Make the sidebar sticky
+.pf-v5-c-sidebar__panel {
+    --pf-v5-c-sidebar__panel--Position: sticky;
+}
+
 .pf-v5-l-gallery {
     --pf-v5-l-gallery--GridTemplateColumns--max: 10rem;
     align-items: start;

--- a/src/app.scss
+++ b/src/app.scss
@@ -85,3 +85,13 @@
 .item-button {
     color: var(--pf-v5-global--Color--200);
 }
+
+// Improve header layout and wrap header text
+.sidebar-panel {
+    .pf-v5-c-card__header-main {
+        display: grid !important;
+        grid-template: 1fr / 1fr auto;
+        overflow-wrap: anywhere;
+        align-items: start;
+    }
+}

--- a/src/app.scss
+++ b/src/app.scss
@@ -95,3 +95,8 @@
         align-items: start;
     }
 }
+
+// Wrap titles of modals (instead of truncating long filenames)
+.pf-v5-c-modal-box__title, .pf-v5-c-modal-box__title-text {
+    white-space: break-spaces;
+}

--- a/src/fileActions.jsx
+++ b/src/fileActions.jsx
@@ -285,6 +285,7 @@ export const RenameItemModal = ({ path, selected, setHistory, setHistoryIndex })
         <Modal
           position="top"
           title={title}
+          variant={ModalVariant.medium}
           isOpen
           onClose={Dialogs.close}
           footer={errorMessage === undefined &&

--- a/src/fileActions.jsx
+++ b/src/fileActions.jsx
@@ -25,7 +25,7 @@ import {
     FormSection,
     FormSelect,
     FormSelectOption,
-    Modal,
+    Modal, ModalVariant,
     Radio,
     Stack,
     TextInput,
@@ -159,6 +159,7 @@ export const ConfirmDeletionDialog = ({
           position="top"
           title={modalTitle}
           titleIconVariant="warning"
+          variant={ModalVariant.small}
           isOpen
           onClose={Dialogs.close}
           footer={

--- a/src/header.jsx
+++ b/src/header.jsx
@@ -40,7 +40,7 @@ const _ = cockpit.gettext;
 
 export const NavigatorCardHeader = ({ currentFilter, onFilterChange, isGrid, setIsGrid, sortBy, setSortBy }) => {
     return (
-        <CardHeader>
+        <CardHeader className="card-actionbar">
             <CardTitle component="h2" id="navigator-card-header">
                 <TextContent>
                     <Text component={TextVariants.h2}>

--- a/src/sidebar.jsx
+++ b/src/sidebar.jsx
@@ -386,7 +386,6 @@ const DropdownWithKebab = ({
 
     return (
         <Dropdown
-          isPlain
           isOpen={isOpen}
           onSelect={onSelect}
           onOpenChange={setIsOpen}


### PR DESCRIPTION
I've split apart my WIP and refactored it quite a bit to fix a bunch of layout-related issues.

Fixes #55

While this does use grid for layout, it doesn't use a grid for everything. I tried, but the layout is too complex as-is, so I went with the sticky solution that I proposed in the issue instead (so the information is still available).

I did remove the PF truncation component as it does not support line clamping. But, with wrapping and line clamping to 3 lines, truncation is not needed nearly as much. (Truncation still happens with an ellipsis when needed, but only at the end. This is a limitation on the way CSS supports truncation. But, as it's rarely needed now with the line wrapping, it's probably a fine tradeoff.)

I've tried to mimic what GNOME's file manager (Nautilus) does for directory and file layouts. (They've gone through several iterations over the years. The latest one works quite well, and we're doing something similar to it with the grid layout and wrapping in icon mode.)