### PR TITLE
package.json: drop flowtype plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,7 @@
     "parserOptions": {
         "ecmaVersion": 2022
     },
-    "plugins": ["flowtype", "react", "react-hooks"],
+    "plugins": ["react", "react-hooks"],
     "rules": {
         "array-bracket-newline": ["error", { "multiline": true }],
         "array-element-newline": [

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "eslint-config-react-app": "^7.0.0",
     "eslint-config-standard": "^17.0.0-1",
     "eslint-config-standard-jsx": "^11.0.0-1",
-    "eslint-plugin-flowtype": "^8.0.3",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.0.0",


### PR DESCRIPTION
None of the Cockpit projects use flowtype's type annotation.