### PR TITLE
Reduce `stat` calls when updating files

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -38,7 +38,7 @@ import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 import { ContextMenu } from "./navigatorContextMenu.jsx";
 import { NavigatorBreadcrumbs } from "./navigatorBreadcrumbs.jsx";
 import {
-    copyItem, createDirectory, createLink, deleteItem, editPermissions, pasteItem, renameItem, updateFile
+    copyItem, createDirectory, createLink, deleteItem, editPermissions, pasteItem, renameItem, updateFiles
 } from "./fileActions.jsx";
 import { SidebarPanelDetails } from "./sidebar.jsx";
 import { NavigatorCardHeader } from "./header.jsx";
@@ -116,11 +116,12 @@ export const Application = () => {
                 setLoadingFiles(false);
             } else {
                 setErrorMessage(null);
-                Promise.all(_files.map(file => updateFile(file, currentDir)))
-                        .then(() => {
-                            setFiles(_files);
+                updateFiles(_files, currentDir)
+                        .then((res) => {
+                            setFiles(res);
                             setLoadingFiles(false);
-                        });
+                        })
+                        .catch(ex => console.warn(ex));
             }
         });
     }, [currentDir]);
@@ -144,8 +145,8 @@ export const Application = () => {
             // When files are created with some file editor we get also 'attribute-changed' and
             // 'done-hint' events which are handled below. We should not add the same file twice.
             if (item.event === "created" && item.type === "directory") {
-                updateFile(item, currentDir).then(file => {
-                    setFiles(_f => [..._f, file]);
+                updateFiles(item, currentDir).then(file => {
+                    setFiles(_f => [..._f, ...file]);
                 });
             } else {
                 if (item.event === "deleted") {

--- a/test/check-application
+++ b/test/check-application
@@ -179,6 +179,10 @@ class TestNavigator(testlib.MachineCase):
         b.click(".breadcrumb-button:nth-of-type(1)")
         b.wait_visible("[data-item='home']")
 
+        # Try opening a directory which contains large amount of files
+        b.mouse("[data-item='bin']", "dblclick")
+        b.wait_visible("[data-item='[']")
+
     def testNavigation(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Navigator currently calls `stat` on a single file. This becomes an issue in directories which contain may files.

This commit attempts to fix it by using a single `stat` call for multiple files and splits very large directories into multiple batches.