### PR TITLE
Python lint fixes

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -8,6 +8,7 @@ import os
 # import Cockpit's machinery for test VMs and its browser test API
 import testlib
 
+
 # Nondestructive tests all run in the same running VM. This allows them to run in Packit, Fedora, and RHEL dist-git gating
 # They must not permanently change any file or configuration on the system in a way that influences other tests.
 @testlib.nondestructive
@@ -321,7 +322,7 @@ class TestNavigator(testlib.MachineCase):
         self.delete_item(b, "file", "newfile")
 
         # Delete file with space in the file name
-        m.execute("touch /home/admin/new\ file")
+        m.execute(r"touch /home/admin/new\ file")
         b.wait_visible("[data-item='new file']")
         self.delete_item(b, "file", "new file")
 

--- a/test/check-application
+++ b/test/check-application
@@ -32,11 +32,11 @@ class TestNavigator(testlib.MachineCase):
         select_entry = f"{selector} ul button:contains('{value}')"
         b.click(select_entry)
 
-    def delete_item(self, b, type, filename, expect_success=True):
+    def delete_item(self, b, filetype, filename, expect_success=True):
         b.click(f"[data-item='{filename}']")
         b.click("#dropdown-menu")
         b.click("#delete-item")
-        b.wait_in_text("h1.pf-v5-c-modal-box__title", f"Delete {type} {filename}?")
+        b.wait_in_text("h1.pf-v5-c-modal-box__title", f"Delete {filetype} {filename}?")
         b.click("button.pf-m-danger")
         if expect_success:
             b.wait_not_present(".pf-v5-c-modal-box")
@@ -51,15 +51,15 @@ class TestNavigator(testlib.MachineCase):
     def wait_modal_inline_alert(self, b, msg):
         b.wait_in_text("h4.pf-v5-c-alert__title", msg)
 
-    def rename_item(self, b, type, itemname, newname):
+    def rename_item(self, b, filetype, itemname, newname):
         b.click(f"[data-item='{itemname}']")
         b.click("#dropdown-menu")
         b.click("#rename-item")
-        b.wait_in_text("h1.pf-v5-c-modal-box__title", f"Rename {type}")
+        b.wait_in_text("h1.pf-v5-c-modal-box__title", f"Rename {filetype}")
         b.set_input_text("#rename-item-input", f"{newname}")
         b.click("button.pf-m-primary")
 
-    def create_link(self, b, original, new, type, index):
+    def create_link(self, b, original, new, filetype, index):
         b.click("#dropdown-menu")
         b.click("#create-link")
         b.focus("#create-link-original-wrapper input")
@@ -69,7 +69,7 @@ class TestNavigator(testlib.MachineCase):
         b.wait_in_text(f"#create-link-original li:nth-of-type({index}) button", original)
         b.click(f"#create-link-original li:nth-of-type({index}) button")
         b.set_input_text("#create-link-new", new)
-        b.click(f"#create-link-{type}")
+        b.click(f"#create-link-{filetype}")
         b.click("button.pf-m-primary")
 
     def testBasic(self):

--- a/test/check-application
+++ b/test/check-application
@@ -9,8 +9,9 @@ import os
 import testlib
 
 
-# Nondestructive tests all run in the same running VM. This allows them to run in Packit, Fedora, and RHEL dist-git gating
-# They must not permanently change any file or configuration on the system in a way that influences other tests.
+# Nondestructive tests all run in the same running VM. This allows them to run
+# in Packit, Fedora, and RHEL dist-git gating They must not permanently change
+# any file or configuration on the system in a way that influences other tests.
 @testlib.nondestructive
 class TestNavigator(testlib.MachineCase):
     @classmethod
@@ -391,7 +392,8 @@ class TestNavigator(testlib.MachineCase):
         b.mouse("[data-item='newdir']", "dblclick")
         b.wait_not_present("[data-item='newdir']")
         self.create_directory(b, "test")
-        self.wait_modal_inline_alert(b, "mkdir: cannot create directory ‘/home/admin/newdir/test’: Operation not permitted")
+        alert_text = "mkdir: cannot create directory ‘/home/admin/newdir/test’: Operation not permitted"
+        self.wait_modal_inline_alert(b, alert_text)
         b.click("div.pf-v5-c-modal-box__close button.pf-v5-c-button")
         b.click(".breadcrumb-button:nth-of-type(3)")
         m.execute("sudo chattr -i /home/admin/newdir")
@@ -496,7 +498,8 @@ class TestNavigator(testlib.MachineCase):
         # Renaming protected item should give an error
         m.execute("sudo chattr +i /home/admin/newdir2")
         self.rename_item(b, "directory", "newdir2", "testdir")
-        self.wait_modal_inline_alert(b, "mv: cannot move '/home/admin/newdir2' to '/home/admin/testdir': Operation not permitted")
+        alert_text = "mv: cannot move '/home/admin/newdir2' to '/home/admin/testdir': Operation not permitted"
+        self.wait_modal_inline_alert(b, alert_text)
         b.click("div.pf-v5-c-modal-box__close")
         m.execute("sudo chattr -i /home/admin/newdir2")
 
@@ -706,7 +709,11 @@ class TestNavigator(testlib.MachineCase):
         self.enter_navigator()
 
         # Copy/paste file
-        m.execute('mkdir /home/admin/newdir && echo "test_text" > /home/admin/newfile && chmod 777 /home/admin/newdir')
+        m.execute("""
+            mkdir /home/admin/newdir
+            echo "test_text" > /home/admin/newfile
+            chmod 777 /home/admin/newdir
+        """)
         b.click("[data-item='newfile']")
         b.click("#dropdown-menu")
         b.click("#copy-item")
@@ -759,15 +766,18 @@ class TestNavigator(testlib.MachineCase):
         # Check error alerts
         b.click("#dropdown-menu")
         b.click("#paste-item")
-        b.wait_in_text("h4.pf-v5-c-alert__title", "Danger alert:cp: '/home/admin/newfile3' and '/home/admin/newfile3' are the same file")
+        b.wait_in_text("h4.pf-v5-c-alert__title",
+                       "'/home/admin/newfile3' and '/home/admin/newfile3' are the same file")
         b.click("div.pf-v5-c-alert__action button")
         m.execute("mkdir /home/admin/locked && chattr +i /home/admin/locked")
         b.mouse("[data-item='locked']", "dblclick")
         b.click("#dropdown-menu")
         b.click("#paste-item")
-        b.wait_in_text("h4.pf-v5-c-alert__title", "Danger alert:cp: cannot create regular file '/home/admin/locked/newfile3': Operation not permitted")
+        b.wait_in_text("h4.pf-v5-c-alert__title",
+                       "cannot create regular file '/home/admin/locked/newfile3': Operation not permitted")
         b.click(".breadcrumb-button:nth-of-type(3)")
         m.execute("chattr -i /home/admin/locked")
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
We don't run `make codecheck` yet as the JS code does not pass yet with:

```
# ✖ 71 problems (71 errors, 0 warnings)
#   65 errors and 0 warnings potentially fixable with the `--fix` option.
```

So this only fixes the Python parts.