### PR TITLE
Two changes for the properties dialog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ LINGUAS=$(basename $(notdir $(wildcard po/*.po)))
 
 po/$(PACKAGE_NAME).js.pot:
 	xgettext --default-domain=$(PACKAGE_NAME) --output=$@ --language=C --keyword= \
+		--add-comments=Translators: \
 		--keyword=_:1,1t --keyword=_:1c,2,2t --keyword=C_:1c,2 \
 		--keyword=N_ --keyword=NC_:1c,2 \
 		--keyword=gettext:1,1t --keyword=gettext:1c,2,2t \

--- a/src/apis/spawnHelpers.jsx
+++ b/src/apis/spawnHelpers.jsx
@@ -113,7 +113,7 @@ export const spawnCreateLink = ({ type, currentPath, originalName, newName, Dial
 };
 
 // eslint-disable-next-line max-len
-export const spawnEditPermissions = ({ ownerAccess, groupAccess, otherAccess, name, path, selected, owner, group, Dialogs, setErrorMessage }) => {
+export const spawnEditPermissions = ({ ownerAccess, groupAccess, otherAccess, path, selected, owner, group, Dialogs, setErrorMessage }) => {
     const command = [
         "chmod",
         ownerAccess + groupAccess + otherAccess,
@@ -125,7 +125,6 @@ export const spawnEditPermissions = ({ ownerAccess, groupAccess, otherAccess, na
         otherAccess !== selected.permissions[2]
     );
     const ownerChanged = owner !== selected.owner || group !== selected.group;
-    const nameChanged = name !== selected.name;
 
     Promise.resolve()
             .then(() => {
@@ -139,10 +138,6 @@ export const spawnEditPermissions = ({ ownerAccess, groupAccess, otherAccess, na
                         options
                     );
                 }
-            })
-            .then(() => {
-                if (nameChanged)
-                    return cockpit.spawn(renameCommand({ selected, path, name }), options);
             })
             .then(Dialogs.close, err => setErrorMessage(err.message));
 };

--- a/src/apis/spawnHelpers.jsx
+++ b/src/apis/spawnHelpers.jsx
@@ -113,12 +113,9 @@ export const spawnCreateLink = ({ type, currentPath, originalName, newName, Dial
 };
 
 // eslint-disable-next-line max-len
-export const spawnEditPermissions = ({ changeAll, ownerAccess, groupAccess, otherAccess, name, path, selected, owner, group, Dialogs, setErrorMessage }) => {
+export const spawnEditPermissions = ({ ownerAccess, groupAccess, otherAccess, name, path, selected, owner, group, Dialogs, setErrorMessage }) => {
     const command = [
         "chmod",
-        ...(changeAll
-            ? ["-R"]
-            : []),
         ownerAccess + groupAccess + otherAccess,
         path.join("/") + "/" + selected.name
     ];

--- a/src/common.js
+++ b/src/common.js
@@ -31,3 +31,10 @@ export const permissions = [
     { label: _("Read, write and execute"), value: "7" },
     { label: _("Write and execute"), value: "3" },
 ];
+
+export const inode_types = {
+    directory: _("Directory"),
+    file: _("Regular file"),
+    link: _("Symbolic link"),
+    special: _("Special file"),
+};

--- a/src/fileActions.jsx
+++ b/src/fileActions.jsx
@@ -470,13 +470,6 @@ export const EditPermissionsModal = ({ selected, path }) => {
                   >
                       {_("Change")}
                   </Button>
-                  {selected.type === "directory" &&
-                  <Button
-                    variant="secondary"
-                    onClick={() => spawnEditPermissions({ ...options, changeAll: true })}
-                  >
-                      {_("Change permissions for enclosed files")}
-                  </Button>}
                   <Button variant="link" onClick={Dialogs.close}>{_("Cancel")}</Button>
               </>
           }

--- a/src/fileActions.jsx
+++ b/src/fileActions.jsx
@@ -48,7 +48,7 @@ import {
     spawnPaste,
     spawnRenameItem
 } from "./apis/spawnHelpers";
-import { permissions } from "./common";
+import { permissions, inode_types } from "./common";
 
 const _ = cockpit.gettext;
 
@@ -387,7 +387,6 @@ export const CreateLinkModal = ({ currentPath, selected }) => {
 
 export const EditPermissionsModal = ({ selected, path }) => {
     const Dialogs = useDialogs();
-    const [name, setName] = useState(selected.name);
     const [owner, setOwner] = useState(selected.owner);
     const [ownerAccess, setOwnerAccess] = useState(selected.permissions[0]);
     const [group, setGroup] = useState(selected.group);
@@ -442,7 +441,6 @@ export const EditPermissionsModal = ({ selected, path }) => {
         Dialogs,
         group,
         groupAccess,
-        name,
         otherAccess,
         owner,
         ownerAccess,
@@ -454,12 +452,10 @@ export const EditPermissionsModal = ({ selected, path }) => {
     return (
         <Modal
           position="top"
-          variant="medium"
-          title={selected.type === "file"
-              ? _("File properties and access")
-              : selected.type === "link"
-                  ? _("Link properties and access")
-                  : _("Directory properties and access")}
+          variant={ModalVariant.small}
+          /* Translators: $0 represents a filename */
+          title={cockpit.format(_("“$0” permissions"), selected.name)}
+          description={inode_types[selected.type] || "Unknown type"}
           isOpen
           onClose={Dialogs.close}
           footer={
@@ -482,18 +478,7 @@ export const EditPermissionsModal = ({ selected, path }) => {
                   isInline
                 />}
                 <Form isHorizontal>
-                    <FormSection title={selected.type === "file"
-                        ? _("File properties")
-                        : selected.type === "link"
-                            ? _("Link properties")
-                            : _("Directory properties")}
-                    >
-                        <FormGroup label={_("Name")} fieldId="edit-permissions-name">
-                            <TextInput
-                              value={name} onChange={(_, val) => setName(val)}
-                              id="edit-permissions-name"
-                            />
-                        </FormGroup>
+                    <FormSection title={_("Ownership")}>
                         <FormGroup label={_("Owner")} fieldId="edit-permissions-owner">
                             <FormSelect
                               onChange={(_, val) => changeOwner(val)} id="edit-permissions-owner"

--- a/test/check-application
+++ b/test/check-application
@@ -586,16 +586,8 @@ class TestNavigator(testlib.MachineCase):
         b.wait_text("#description-list-group-permissions dd", "Read-only")
         b.wait_text("#description-list-other-permissions dd", "Read-only")
 
-        # Test renaming item
-        b.click("button:contains('Edit properties')")
-        b.set_input_text("#edit-permissions-name", "newfile1")
-        b.click("button.pf-m-primary")
-        b.wait_not_present("[data-item='newfile']")
-        b.wait_visible("[data-item='newfile1']")
-
         # Test changing owner/group
         m.execute("useradd testuser")
-        b.click("[data-item='newfile1']")
         b.click("button:contains('Edit properties')")
         # Changing owner should change group if user is not in the group
         b.select_from_dropdown("#edit-permissions-owner", "testuser")
@@ -617,13 +609,13 @@ class TestNavigator(testlib.MachineCase):
         b.click("button:contains('Edit properties')")
         select_access("0")
         b.click("button.pf-m-primary")
-        self.assertEqual(m.execute("ls -l /home/admin/newfile1")[:10], "----------")
+        self.assertEqual(m.execute("ls -l /home/admin/newfile")[:10], "----------")
         wait_permissions("None")
 
         b.click("button:contains('Edit properties')")
         select_access("7")
         b.click("button.pf-m-primary")
-        self.assertEqual(m.execute("ls -l /home/admin/newfile1")[:10], "-rwxrwxrwx")
+        self.assertEqual(m.execute("ls -l /home/admin/newfile")[:10], "-rwxrwxrwx")
         wait_permissions("Read, write and execute")
 
     def testErrors(self):

--- a/test/check-application
+++ b/test/check-application
@@ -626,19 +626,6 @@ class TestNavigator(testlib.MachineCase):
         self.assertEqual(m.execute("ls -l /home/admin/newfile1")[:10], "-rwxrwxrwx")
         wait_permissions("Read, write and execute")
 
-        # Check changing permissions for all files in folder
-        m.execute("mkdir /home/admin/newdir")
-        m.execute("touch /home/admin/newdir/file1")
-        m.execute("touch /home/admin/newdir/file2")
-        b.click("[data-item='newdir']")
-        b.click("button:contains('Edit properties')")
-        select_access("7")
-        b.click("button.pf-m-secondary:contains('Change permissions for enclosed files')")
-        self.assertEqual(m.execute("ls -ld /home/admin/newdir")[:10], "drwxrwxrwx")
-        wait_permissions("Read, write and execute")
-        self.assertEqual(m.execute("ls -l /home/admin/newdir/file1")[:10], "-rwxrwxrwx")
-        self.assertEqual(m.execute("ls -l /home/admin/newdir/file2")[:10], "-rwxrwxrwx")
-
     def testErrors(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
 - drop rename support
 - drop recursive chmod support

before:
![image](https://github.com/cockpit-project/cockpit-navigator/assets/36541154/fc96616a-f7b8-46fe-a87d-657382b2d574)

after:
![image](https://github.com/cockpit-project/cockpit-navigator/assets/36541154/fdc30f8b-0893-4731-b3c8-0c22ba89b950)
