### PR TITLE
Use cockpit's new 'fsinfo' channel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,12 @@ rpm: $(TARFILE) $(NODE_CACHE) $(SPEC)
 	rm -r "`pwd`/rpmbuild"
 	rm -r "`pwd`/output" "`pwd`/build"
 
-ifeq ("$(TEST_SCENARIO)","pybridge")
+# HACK: we need the 'fsinfo' channel supported only in the Python bridge, and
+# only on the `main` branch of Cockpit (and not in any released version yet).
+# We can re-engage our 'pybridge' scenario logic, which creates and installs a
+# wheel from upstream cockpit git. We should remove this once we get all of our
+# images with the updated version of the bridge.
+ifeq ("pybridge","pybridge")
 COCKPIT_PYBRIDGE_REF = main
 COCKPIT_WHEEL = cockpit-0-py3-none-any.whl
 
@@ -176,13 +181,13 @@ $(COCKPIT_WHEEL):
 	pip wheel git+https://github.com/cockpit-project/cockpit.git@${COCKPIT_PYBRIDGE_REF}
 
 VM_DEPENDS = $(COCKPIT_WHEEL)
-VM_CUSTOMIZE_FLAGS = --install $(COCKPIT_WHEEL)
+VM_CUSTOMIZE_FLAGS = --upload $(COCKPIT_WHEEL):/var/tmp --script test/install-wheel
 endif
 
 # build a VM with locally built distro pkgs installed
 # disable networking, VM images have mock/pbuilder with the common build dependencies pre-installed
 $(VM_IMAGE): $(TARFILE) $(NODE_CACHE) packaging/arch/PKGBUILD bots test/vm.install $(VM_DEPENDS)
-	bots/image-customize --no-network --fresh \
+	bots/image-customize --fresh \
 		$(VM_CUSTOMIZE_FLAGS) \
 		--upload $(NODE_CACHE):/var/tmp/ --build $(TARFILE) \
 		--script $(CURDIR)/test/vm.install $(TEST_OS)

--- a/src/apis/spawnHelpers.jsx
+++ b/src/apis/spawnHelpers.jsx
@@ -91,7 +91,7 @@ export const spawnRenameItem = ({ selected, name, path, Dialogs, setErrorMessage
 
 export const spawnCreateDirectory = ({ name, currentPath, selected, Dialogs, setErrorMessage }) => {
     let path;
-    if (selected.icons_cnt || selected.type === "directory") {
+    if (selected.icons_cnt || selected.type === "dir") {
         path = currentPath + selected.name + "/" + name;
     } else {
         path = currentPath + name;
@@ -112,31 +112,18 @@ export const spawnCreateLink = ({ type, currentPath, originalName, newName, Dial
             .then(Dialogs.close, (err) => { setErrorMessage(err.message) });
 };
 
-// eslint-disable-next-line max-len
-export const spawnEditPermissions = ({ ownerAccess, groupAccess, otherAccess, path, selected, owner, group, Dialogs, setErrorMessage }) => {
-    const command = [
-        "chmod",
-        ownerAccess + groupAccess + otherAccess,
-        path.join("/") + "/" + selected.name
-    ];
-    const permissionChanged = (
-        ownerAccess !== selected.permissions[0] ||
-        groupAccess !== selected.permissions[1] ||
-        otherAccess !== selected.permissions[2]
-    );
-    const ownerChanged = owner !== selected.owner || group !== selected.group;
+export const spawnEditPermissions = ({ mode, path, selected, owner, group, Dialogs, setErrorMessage }) => {
+    const permissionChanged = mode !== selected.mode;
+    const ownerChanged = owner !== selected.user || group !== selected.group;
 
     Promise.resolve()
             .then(() => {
                 if (permissionChanged)
-                    return cockpit.spawn(command, options);
+                    return cockpit.spawn(["chmod", mode.toString(8), path.join("/") + "/" + selected.name], options);
             })
             .then(() => {
                 if (ownerChanged) {
-                    return cockpit.spawn(
-                        ["chown", owner + ":" + group, path.join("/") + "/" + selected.name],
-                        options
-                    );
+                    return cockpit.spawn(["chown", owner + ":" + group, path.join("/") + "/" + selected.name], options);
                 }
             })
             .then(Dialogs.close, err => setErrorMessage(err.message));

--- a/src/common.ts
+++ b/src/common.ts
@@ -22,19 +22,32 @@ import cockpit from "cockpit";
 const _ = cockpit.gettext;
 
 export const permissions = [
-    { label: _("None"), value: "0" },
-    { label: _("Read-only"), value: "4" },
-    { label: _("Write-only"), value: "2" },
-    { label: _("Execute-only"), value: "1" },
-    { label: _("Read and write"), value: "6" },
-    { label: _("Read and execute"), value: "5" },
-    { label: _("Read, write and execute"), value: "7" },
-    { label: _("Write and execute"), value: "3" },
+    /* 0 */ _("None"),
+    /* 1 */ _("Execute-only"),
+    /* 2 */ _("Write-only"),
+    /* 3 */ _("Write and execute"),
+    /* 4 */ _("Read-only"),
+    /* 5 */ _("Read and execute"),
+    /* 6 */ _("Read and write"),
+    /* 7 */ _("Read, write and execute"),
 ];
 
 export const inode_types = {
-    directory: _("Directory"),
-    file: _("Regular file"),
-    link: _("Symbolic link"),
-    special: _("Special file"),
+    blk: _("Block device"),
+    chr: _("Character device"),
+    dir: _("Directory"),
+    fifo: _("Named pipe"),
+    lnk: _("Symbolic link"),
+    reg: _("Regular file"),
+    sock: _("Socket"),
 };
+
+export function get_permissions(n: number) {
+    return permissions[n & 0o7];
+}
+
+export function * map_permissions<T>(func: (value: number, label: string) => T) {
+    for (const [value, label] of permissions.entries()) {
+        yield func(value, label);
+    }
+}

--- a/src/fsinfo.ts
+++ b/src/fsinfo.ts
@@ -1,0 +1,139 @@
+"use strict";
+
+import cockpit from "cockpit";
+
+function is_json_dict(value: cockpit.JsonValue): value is cockpit.JsonObject {
+    return value?.constructor === Object;
+}
+
+/* RFC 7396 — JSON Merge Patch — functional */
+function json_merge(current: cockpit.JsonValue, patch: cockpit.JsonValue): cockpit.JsonValue {
+    if (is_json_dict(patch)) {
+        const updated = is_json_dict(current) ? { ...current } : { };
+
+        for (const [key, value] of Object.entries(patch)) {
+            if (value === null) {
+                delete updated[key];
+            } else {
+                updated[key] = json_merge(updated[key], value);
+            }
+        }
+
+        return updated;
+    } else {
+        return patch;
+    }
+}
+
+interface FileInfo {
+    type?: string;
+    tag?: string;
+    mode?: number;
+    size?: number;
+    uid?: number;
+    user?: string | number;
+    gid?: number;
+    group?: string | number;
+    mtime?: number;
+    content?: string;
+    target?: string;
+    entries?: {
+        [filename: string]: FileInfo;
+    };
+    targets?: {
+        [filename: string]: FileInfo;
+    };
+}
+
+interface FsInfoError {
+    problem?: string;
+    message?: string;
+    errno?: string;
+}
+
+interface FileInfoState {
+    info: FileInfo | null;
+    error: FsInfoError | null;
+    loading: boolean;
+}
+
+interface FsInfoHandle {
+    close(): void;
+    effect(callback: ((state: FileInfoState) => void)): void;
+    entry(name: string): FileInfo | null;
+    state: FileInfoState;
+    target(name: string): FileInfo | null;
+}
+
+export function fsinfo(path: string, attrs: string[], options?: cockpit.JsonObject) {
+    const self: FsInfoHandle = {
+        close,
+        effect,
+        entry,
+        state: {
+            info: null,
+            error: null,
+            loading: true,
+        },
+        target,
+    };
+
+    const callbacks: ((state: FileInfoState) => void)[] = [];
+
+    function close() {
+        channel.close();
+    }
+
+    function effect(callback: (state: FileInfoState) => void) {
+        callback(self.state);
+        callbacks.push(callback);
+        return () => callbacks.splice(callbacks.indexOf(callback), 1);
+    }
+
+    function entry(name: string): FileInfo | null {
+        return self.state.info?.entries?.[name] ?? null;
+    }
+
+    function target(name: string): FileInfo | null {
+        const entries = self.state.info?.entries ?? {};
+        const targets = self.state.info?.targets ?? {};
+
+        let entry = entries[name] ?? null;
+        for (let i = 0; i < 40; i++) {
+            const target = entry?.target;
+            if (!target)
+                return entry;
+            entry = entries[target] ?? targets[target] ?? null;
+        }
+        return null; // ELOOP
+    }
+
+    const channel = cockpit.channel({
+        superuser: "try",
+        payload: "fsinfo",
+        path,
+        attrs,
+        "close-on-error": false,
+        watch: true,
+        ...options
+    });
+
+    let state: cockpit.JsonValue = null;
+    channel.addEventListener("message", (_event: CustomEvent, payload: string) => {
+        state = json_merge(state, JSON.parse(payload));
+
+        if (is_json_dict(state) && !state.partial) {
+            self.state = {
+                info: is_json_dict(state.info) ? state.info : null,
+                error: is_json_dict(state.error) ? state.error : null,
+                loading: false
+            };
+
+            for (const callback of callbacks) {
+                callback(self.state);
+            }
+        }
+    });
+
+    return self;
+}

--- a/src/sidebar.jsx
+++ b/src/sidebar.jsx
@@ -55,32 +55,28 @@ import { useDialogs } from "dialogs.jsx";
 import {
     copyItem, createDirectory, createLink, deleteItem, editPermissions, pasteItem, renameItem
 } from "./fileActions.jsx";
-import { permissions } from "./common.js";
+import { get_permissions } from "./common";
 
 const _ = cockpit.gettext;
 
 const getDescriptionListItems = selected => {
-    const getPermissions = (str) => {
-        return permissions.find(e => e.value === str).label;
-    };
-
     return ([
         {
             id: "description-list-last-modified",
             label: _("Last modified"),
-            value: timeformat.dateTime(selected.modified * 1000)
+            value: timeformat.dateTime(selected.mtime * 1000)
         },
         {
             id: "description-list-owner",
             label: _("Owner"),
-            value: selected.owner
+            value: selected.user
         },
         {
             id: "description-list-group",
             label: _("Group"),
             value: selected.group
         },
-        ...(selected.type === "file"
+        ...(selected.type === "reg"
             ? [
                 {
                     id: "description-list-size",
@@ -98,17 +94,17 @@ const getDescriptionListItems = selected => {
         {
             id: "description-list-owner-permissions",
             label: _("Owner permissions"),
-            value: getPermissions(selected.permissions[0])
+            value: get_permissions(selected.mode >> 6),
         },
         {
             id: "description-list-group-permissions",
             label: _("Group permissions"),
-            value: getPermissions(selected.permissions[1])
+            value: get_permissions(selected.mode >> 3),
         },
         {
             id: "description-list-other-permissions",
             label: _("Other permissions"),
-            value: getPermissions(selected.permissions[2])
+            value: get_permissions(selected.mode >> 0),
         },
     ]);
 };
@@ -278,7 +274,7 @@ const DropdownWithKebab = ({
                 }
             ]
             : [],
-        ...(selected.length === 1 && selected[0].type === "directory")
+        ...(selected.length === 1 && selected[0].type === "dir")
             ? [
                 {
                     id: "paste-into-directory",

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -21,6 +21,9 @@ if grep -q platform:el8 /etc/os-release; then
     dnf module switch-to -y nodejs:16
 fi
 
+# Install cockpit from git main (for fsinfo)
+TMPDIR=/var/tmp pip install git+https://github.com/cockpit-project/cockpit.git@main
+
 # create user account for logging in
 if ! id admin 2>/dev/null; then
     useradd -c Administrator -G wheel admin

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -10,5 +10,6 @@ require:
   - make
   - npm
   - python3
+  - python3-pip
 test: ./browser.sh
 duration: 60m

--- a/test/check-application
+++ b/test/check-application
@@ -243,6 +243,7 @@ class TestNavigator(testlib.MachineCase):
         b.wait_not_present("[data-item='newdir']")
         b.wait_text(".last-breadcrumb-button", "newdir2")
         b.click("#navigate-forward")
+        b.click("#navigator-card-body")  # unselect
         b.wait_in_text("#sidebar-card-header", "home")
         b.wait_not_present("[data-item='newdir']")
         b.wait_text(".last-breadcrumb-button", "home")
@@ -743,6 +744,7 @@ class TestNavigator(testlib.MachineCase):
         b.click(".breadcrumb-button:nth-of-type(3)")
 
         # Check error alerts
+        b.click("#navigator-card-body")  # unselect
         b.click("#dropdown-menu")
         b.click("#paste-item")
         b.wait_in_text("h4.pf-v5-c-alert__title",

--- a/test/install-wheel
+++ b/test/install-wheel
@@ -1,0 +1,20 @@
+#!/bin/sh -eux
+
+. /usr/lib/os-release
+
+WHEEL='/var/tmp/cockpit-0-py3-none-any.whl'
+
+case "${ID}" in
+    arch)
+        pacman -Sy --noconfirm python-pip
+        pip install --prefix=/usr "${WHEEL}"
+        ;;
+    debian)
+        apt-get update
+        apt-get install -y python3-pip
+        pip install --break-system-packages "${WHEEL}"
+        ;;
+    *)
+        pip install "${WHEEL}"
+        ;;
+esac


### PR DESCRIPTION
Substantially rework navigator to be based on the new 'fsinfo' channel provided by Cockpit.

This new channel is only on the Python bridge, and has yet to appear in a released version of Cockpit, so (unconditionally) re-engage our existing code to install a version of the wheel from cockpit git.

We also temporarily host some code here (fsinfo.ts) which will eventually make its way into cockpit.js.

In addition to being a simplification of the code, this *dramatically* improves the performance of cockpit-navigator, making it possible to open large directories, such as /usr/lib64.  Some quick measurements on that directory show that it takes only 58ms until we get the full set of data from the channel and convert it into the list of files for the navigator.  From there, the performance of React isn't excellent, but we can fix that in the future using something like `react-windowed` or PatternFly's `react-virtualized-extension`.

This is a very rough first pass which tried to avoid touching too much unrelated code, but despite that, there were quite some changes (since the use of the old data model reached deep into various corners of the codes, and they needed to be updated).

Closes: #137

 - [x] https://github.com/cockpit-project/cockpit-navigator/pull/211
 - [x] https://github.com/cockpit-project/cockpit/pull/19900
 - [ ] Once this is in a released cockpit version, bump the cockpit-bridge dependency in manifest and packaging
