### PR TITLE
Context menus: Use "Edit permissions" consistently

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -192,7 +192,7 @@ export const Application = () => {
     };
     const _pasteItem = (targetPath, asSymlink) => pasteItem(clipboard, targetPath.join("/") + "/", asSymlink, addAlert);
     const _renameItem = () => renameItem(Dialogs, { selected: selectedContext, path, setHistory, setHistoryIndex });
-    const _editProperties = () => editPermissions(Dialogs, { selected: selectedContext, path });
+    const _editPermissions = () => editPermissions(Dialogs, { selected: selectedContext, path });
     const _deleteItem = () => {
         deleteItem(
             Dialogs,
@@ -226,7 +226,7 @@ export const Application = () => {
                         { title: _("Create directory"), onClick: _createDirectory },
                         { title: _("Create link"), onClick: _createLink },
                         { type: "divider" },
-                        { title: _("Edit properties"), onClick: _editProperties }
+                        { title: _("Edit permissions"), onClick: _editPermissions }
                     ]
                     : selected.length > 1 && selected.includes(selectedContext)
                     // eslint-disable-next-line max-len
@@ -243,7 +243,7 @@ export const Application = () => {
                                 ]
                                 : [],
                             { type: "divider" },
-                            { title: _("Edit properties"), onClick: _editProperties },
+                            { title: _("Edit permissions"), onClick: _editPermissions },
                             { title: _("Rename"), onClick: _renameItem },
                             { type: "divider" },
                             { title: _("Create link"), onClick: _createLink },

--- a/src/sidebar.jsx
+++ b/src/sidebar.jsx
@@ -197,7 +197,7 @@ export const SidebarPanelDetails = ({
                       editPermissions(Dialogs, { selected: selected[0], path });
                   }}
                 >
-                    {_("Edit properties")}
+                    {_("Edit permissions")}
                 </Button>
             </CardBody>}
         </Card>
@@ -317,7 +317,7 @@ const DropdownWithKebab = ({
         },
         { type: "divider" },
         {
-            id: "edit-properties",
+            id: "edit-permissions",
             onClick: () => {
                 editPermissions(Dialogs, {
                     selected: selected.length === 0
@@ -326,7 +326,7 @@ const DropdownWithKebab = ({
                     path
                 });
             },
-            title: _("Edit properties")
+            title: _("Edit permissions")
         },
         {
             id: "rename-item",

--- a/test/check-application
+++ b/test/check-application
@@ -429,12 +429,12 @@ class TestNavigator(testlib.MachineCase):
         b.click("button.pf-m-primary")
         b.wait_visible("[data-item='newdir1']")
 
-        # Edit properties from context menu
+        # Edit permissions from context menu
         m.execute("useradd testuser")
         b.click("[data-item='newdir1']")
         b.mouse("[data-item='newdir1']", "contextmenu")
-        b.wait_in_text(".context-menu li:nth-child(4) button", "Edit properties")
-        b.click(".context-menu button:contains('Edit properties')")
+        b.wait_in_text(".context-menu li:nth-child(4) button", "Edit permissions")
+        b.click(".context-menu button:contains('Edit permissions')")
         b.select_from_dropdown("#edit-permissions-owner", "testuser")
         b.click("button.pf-m-primary")
         b.wait_text("#description-list-owner dd", "testuser")
@@ -588,7 +588,7 @@ class TestNavigator(testlib.MachineCase):
 
         # Test changing owner/group
         m.execute("useradd testuser")
-        b.click("button:contains('Edit properties')")
+        b.click("button:contains('Edit permissions')")
         # Changing owner should change group if user is not in the group
         b.select_from_dropdown("#edit-permissions-owner", "testuser")
         b.wait_in_text("#edit-permissions-group", "testuser")
@@ -597,7 +597,7 @@ class TestNavigator(testlib.MachineCase):
         b.wait_text("#description-list-group dd", "testuser")
 
         m.execute("usermod -a -G testuser admin")
-        b.click("button:contains('Edit properties')")
+        b.click("button:contains('Edit permissions')")
         # Changing owner shouldn't change group if user is in the group
         b.select_from_dropdown("#edit-permissions-owner", "admin")
         b.wait_in_text("#edit-permissions-group", "testuser")
@@ -606,13 +606,13 @@ class TestNavigator(testlib.MachineCase):
         b.wait_text("#description-list-group dd", "testuser")
 
         # Test changing permissions
-        b.click("button:contains('Edit properties')")
+        b.click("button:contains('Edit permissions')")
         select_access("0")
         b.click("button.pf-m-primary")
         self.assertEqual(m.execute("ls -l /home/admin/newfile")[:10], "----------")
         wait_permissions("None")
 
-        b.click("button:contains('Edit properties')")
+        b.click("button:contains('Edit permissions')")
         select_access("7")
         b.click("button.pf-m-primary")
         self.assertEqual(m.execute("ls -l /home/admin/newfile")[:10], "-rwxrwxrwx")


### PR DESCRIPTION
We have a dialog for editing permissions, with "permissions" in the title, but we consistently call the menu item "Edit properties".

Change the menu item to match the dialog title.

Closes #207