### PR TITLE
Show navigator as file browser in Cockpit

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,7 +5,12 @@
 
   "tools": {
       "index": {
-          "label": "Navigator"
+          "label": "File browser",
+          "keywords": [
+		{
+			"matches": ["files", "navigator", "explorer", "filesystem"]
+		}
+	  ]
       }
   },
   "content-security-policy": "img-src 'self' data:; frame-src 'self' data:"


### PR DESCRIPTION
As discussed in the recent SPUR, rename navigator to "File browser" which is more obvious then navigator. Further more add some keywords so users can find it, as the old 45Drives project was called navigator allow it to be found when searching for navigator.

![image](https://github.com/cockpit-project/cockpit-navigator/assets/67428/17c2c2a9-5f4d-42c6-b204-16fcb6dfa2e0)
