### PR TITLE
Refactor Navigator Card Body for global event listeners

### DIFF
--- a/src/apis/spawnHelpers.jsx
+++ b/src/apis/spawnHelpers.jsx
@@ -89,13 +89,8 @@ export const spawnRenameItem = ({ selected, name, path, Dialogs, setErrorMessage
             }, err => setErrorMessage(err.message));
 };
 
-export const spawnCreateDirectory = ({ name, currentPath, selected, Dialogs, setErrorMessage }) => {
-    let path;
-    if (selected.icons_cnt || selected.type === "dir") {
-        path = currentPath + selected.name + "/" + name;
-    } else {
-        path = currentPath + name;
-    }
+export const spawnCreateDirectory = ({ name, currentPath, Dialogs, setErrorMessage }) => {
+    const path = currentPath + name;
     cockpit.spawn(["mkdir", path], options)
             .then(Dialogs.close, err => setErrorMessage(err.message));
 };

--- a/src/apis/spawnHelpers.jsx
+++ b/src/apis/spawnHelpers.jsx
@@ -30,13 +30,11 @@ const renameCommand = ({ selected, path, name }) => {
         : ["mv", path.join("/") + "/" + selected.name, path.join("/") + "/" + name];
 };
 
-export const spawnDeleteItem = ({ path, selected, itemPath, Dialogs, setSelected, setHistory, setHistoryIndex }) => {
+export const spawnDeleteItem = ({ path, selected, Dialogs, setSelected, setHistory, setHistoryIndex }) => {
     cockpit.spawn([
         "rm",
         "-r",
-        ...selected.length > 1
-            ? selected.map(f => path + f.name)
-            : [itemPath]
+        ...selected.map(f => path + f.name)
     ], options)
             .then(() => {
                 setSelected([]);
@@ -52,20 +50,19 @@ export const spawnDeleteItem = ({ path, selected, itemPath, Dialogs, setSelected
             .catch(err => {
                 Dialogs.show(
                     <ForceDeleteModal
-                      selected={selected} itemPath={itemPath}
+                      path={path}
+                      selected={selected}
                       initialError={err.message}
                     />
                 );
             });
 };
 
-export const spawnForceDelete = ({ selected, path, itemPath, Dialogs, setDeleteFailed, setErrorMessage }) => {
+export const spawnForceDelete = ({ selected, path, Dialogs, setDeleteFailed, setErrorMessage }) => {
     cockpit.spawn([
         "rm",
         "-r",
-        ...selected.length > 1
-            ? selected.map(f => path + f.name)
-            : [itemPath]
+        ...selected.map(f => path + f.name)
     ], options)
             .then(Dialogs.close, err => {
                 setDeleteFailed(true);

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -49,7 +49,6 @@ export const Application = () => {
     const [isGrid, setIsGrid] = useState(true);
     const [sortBy, setSortBy] = useState(localStorage.getItem("cockpit-navigator.sort") || "az");
     const [selected, setSelected] = useState([]);
-    const [selectedContext, setSelectedContext] = useState(null);
     const [showHidden, setShowHidden] = useState(localStorage.getItem("cockpit-navigator.showHiddenFiles") === "true");
     const [history, setHistory] = useState([]);
     const [historyIndex, setHistoryIndex] = useState(0);
@@ -122,11 +121,7 @@ export const Application = () => {
               setHistory={setHistory} history={history}
               historyIndex={historyIndex} setHistoryIndex={setHistoryIndex}
             />
-            <PageSection onContextMenu={() => {
-                setSelectedContext(null);
-                setSelected([{ name: sel }]);
-            }}
-            >
+            <PageSection>
                 <Sidebar isPanelRight hasGutter>
                     <SidebarContent>
                         <Card>
@@ -142,8 +137,7 @@ export const Application = () => {
                               currentDir={currentDir}
                               isGrid={isGrid} sortBy={sortBy}
                               selected={selected} setSelected={setSelected}
-                              selectedContext={selectedContext}
-                              setSelectedContext={setSelectedContext} setHistory={setHistory}
+                              setHistory={setHistory}
                               setHistoryIndex={setHistoryIndex} historyIndex={historyIndex}
                               loadingFiles={loadingFiles}
                               clipboard={clipboard}

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -45,6 +45,7 @@ export const Application = () => {
     const [errorMessage, setErrorMessage] = useState();
     const [currentFilter, setCurrentFilter] = useState("");
     const [files, setFiles] = useState([]);
+    // eslint-disable-next-line no-unused-vars
     const [rootInfo, setRootInfo] = useState();
     const [isGrid, setIsGrid] = useState(true);
     const [sortBy, setSortBy] = useState(localStorage.getItem("cockpit-navigator.sort") || "az");
@@ -143,7 +144,6 @@ export const Application = () => {
                               clipboard={clipboard}
                               setClipboard={setClipboard}
                               addAlert={addAlert}
-                              rootInfo={rootInfo}
                               allFiles={files}
                             />
                             <AlertGroup isToast isLiveRegion>

--- a/src/context-menu.jsx
+++ b/src/context-menu.jsx
@@ -23,7 +23,7 @@ import { Menu, MenuContent } from "@patternfly/react-core";
 
 import "./context-menu.scss";
 
-export const ContextMenu = ({ parentId, contextMenuItems, setSelectedContext }) => {
+export const ContextMenu = ({ parentId, contextMenuItems }) => {
     const [visible, setVisible] = React.useState(false);
     const [event, setEvent] = React.useState(null);
     const root = React.useRef(null);
@@ -41,7 +41,6 @@ export const ContextMenu = ({ parentId, contextMenuItems, setSelectedContext }) 
 
                 if (wasOutside) {
                     setVisible(false);
-                    setSelectedContext(null);
                 }
             }
         };
@@ -54,7 +53,7 @@ export const ContextMenu = ({ parentId, contextMenuItems, setSelectedContext }) 
             parent.removeEventListener("contextmenu", _handleContextMenu);
             document.removeEventListener("click", _handleClick);
         };
-    }, [parentId, setSelectedContext]);
+    }, [parentId]);
 
     React.useEffect(() => {
         if (!event)

--- a/src/fileActions.jsx
+++ b/src/fileActions.jsx
@@ -72,10 +72,9 @@ export const createLink = (Dialogs, currentPath, files, selected) => {
 export const deleteItem = (Dialogs, options) => {
     Dialogs.show(
         <ConfirmDeletionDialog
-          selected={options.selected} itemPath={options.itemPath}
+          selected={options.selected}
           path={options.path} setSelected={options.setSelected}
           setHistory={options.setHistory} setHistoryIndex={options.setHistoryIndex}
-          currentDirectory={options.currentDirectory}
         />
     );
 };
@@ -107,13 +106,11 @@ export const pasteItem = (clipboard, targetPath, asSymlink, addAlert) => {
 };
 
 export const ConfirmDeletionDialog = ({
-    itemPath,
     path,
     selected,
     setHistory,
     setHistoryIndex,
     setSelected,
-    currentDirectory
 }) => {
     const Dialogs = useDialogs();
 
@@ -121,9 +118,7 @@ export const ConfirmDeletionDialog = ({
     if (selected.length > 1) {
         modalTitle = cockpit.format(_("Delete $0 items?"), selected.length);
     } else {
-        const selectedItem = selected.length === 1
-            ? selected[0]
-            : currentDirectory;
+        const selectedItem = selected[0];
         if (selectedItem.type === "reg") {
             modalTitle = cockpit.format(_("Delete file $0?"), selectedItem.name);
         } else if (selectedItem.type === "lnk") {
@@ -136,7 +131,7 @@ export const ConfirmDeletionDialog = ({
     }
 
     const deleteItem = () => {
-        spawnDeleteItem({ Dialogs, selected, itemPath, path, setHistory, setHistoryIndex, setSelected });
+        spawnDeleteItem({ Dialogs, selected, path, setHistory, setHistoryIndex, setSelected });
     };
 
     return (
@@ -157,7 +152,7 @@ export const ConfirmDeletionDialog = ({
     );
 };
 
-export const ForceDeleteModal = ({ selected, itemPath, initialError }) => {
+export const ForceDeleteModal = ({ selected, path, initialError }) => {
     const Dialogs = useDialogs();
     const [errorMessage, setErrorMessage] = useState(initialError);
     const [deleteFailed, setDeleteFailed] = useState(false);
@@ -181,7 +176,7 @@ export const ForceDeleteModal = ({ selected, itemPath, initialError }) => {
     }
 
     const forceDeleteItem = () => {
-        spawnForceDelete({ Dialogs, selected, itemPath, setDeleteFailed, setErrorMessage });
+        spawnForceDelete({ Dialogs, selected, path, setDeleteFailed, setErrorMessage });
     };
 
     return (

--- a/src/fileActions.jsx
+++ b/src/fileActions.jsx
@@ -52,8 +52,8 @@ import { map_permissions, inode_types } from "./common";
 
 const _ = cockpit.gettext;
 
-export const createDirectory = (Dialogs, currentPath, selected) => {
-    Dialogs.show(<CreateDirectoryModal currentPath={currentPath} selected={selected} />);
+export const createDirectory = (Dialogs, currentPath) => {
+    Dialogs.show(<CreateDirectoryModal currentPath={currentPath} />);
 };
 
 export const createLink = (Dialogs, currentPath, files, selected) => {
@@ -206,12 +206,12 @@ export const ForceDeleteModal = ({ selected, itemPath, initialError }) => {
     );
 };
 
-export const CreateDirectoryModal = ({ selected, currentPath }) => {
+export const CreateDirectoryModal = ({ currentPath }) => {
     const Dialogs = useDialogs();
     const [name, setName] = useState("");
     const [errorMessage, setErrorMessage] = useState(undefined);
     const createDirectory = () => {
-        spawnCreateDirectory({ Dialogs, selected, currentPath, name, setErrorMessage });
+        spawnCreateDirectory({ Dialogs, currentPath, name, setErrorMessage });
     };
 
     return (

--- a/src/navigator-card-body.jsx
+++ b/src/navigator-card-body.jsx
@@ -94,7 +94,7 @@ const ContextMenuItems = ({ path, currentDir, selected, selectedContext, setSele
             : [currentDir + selected[0].name]);
     };
     const _pasteItem = (targetPath, asSymlink) => pasteItem(clipboard, targetPath.join("/") + "/", asSymlink, addAlert);
-    const _renameItem = () => renameItem(Dialogs, { selected: selectedContext, path, setHistory, setHistoryIndex });
+    const _renameItem = () => renameItem(Dialogs, { selected: selected[0], path, setHistory, setHistoryIndex });
     const _editPermissions = () => editPermissions(Dialogs, { selected: selectedContext || rootInfo, path });
     const _deleteItem = () => {
         deleteItem(

--- a/src/navigator-card-body.jsx
+++ b/src/navigator-card-body.jsx
@@ -101,7 +101,6 @@ const ContextMenuItems = ({ path, currentDir, selected, selectedContext, setSele
             Dialogs,
             {
                 selected,
-                itemPath: currentDir + selectedContext.name,
                 setHistory,
                 setHistoryIndex,
                 path: currentDir,

--- a/src/navigator-card-body.jsx
+++ b/src/navigator-card-body.jsx
@@ -87,7 +87,7 @@ const ContextMenuItems = ({ path, currentDir, selected, selectedContext, setSele
     const Dialogs = useDialogs();
 
     const _createDirectory = () => createDirectory(Dialogs, currentDir);
-    const _createLink = () => createLink(Dialogs, currentDir, files, selectedContext);
+    const _createLink = () => createLink(Dialogs, currentDir, files, selected[0]);
     const _copyItem = () => {
         copyItem(setClipboard, selected.length > 1
             ? selected.map(s => currentDir + s.name)

--- a/src/navigator-card-body.jsx
+++ b/src/navigator-card-body.jsx
@@ -83,7 +83,7 @@ const compare = (sortBy) => {
 };
 
 // eslint-disable-next-line max-len
-const ContextMenuItems = ({ path, currentDir, selected, selectedContext, setSelected, setHistory, setHistoryIndex, addAlert, rootInfo, clipboard, setClipboard, files }) => {
+const ContextMenuItems = ({ path, currentDir, selected, selectedContext, setSelected, setHistory, setHistoryIndex, addAlert, clipboard, setClipboard, files }) => {
     const Dialogs = useDialogs();
 
     const _createDirectory = () => createDirectory(Dialogs, currentDir);
@@ -95,7 +95,7 @@ const ContextMenuItems = ({ path, currentDir, selected, selectedContext, setSele
     };
     const _pasteItem = (targetPath, asSymlink) => pasteItem(clipboard, targetPath.join("/") + "/", asSymlink, addAlert);
     const _renameItem = () => renameItem(Dialogs, { selected: selected[0], path, setHistory, setHistoryIndex });
-    const _editPermissions = () => editPermissions(Dialogs, { selected: selectedContext || rootInfo, path });
+    const _editPermissions = () => editPermissions(Dialogs, { selected: selected[0], path });
     const _deleteItem = () => {
         deleteItem(
             Dialogs,
@@ -181,7 +181,6 @@ export const NavigatorCardBody = ({
     setClipboard,
     addAlert,
     allFiles,
-    rootInfo,
 }) => {
     const [boxPerRow, setBoxPerRow] = useState(0);
     const [selectedContext, setSelectedContext] = useState(null);
@@ -398,7 +397,6 @@ export const NavigatorCardBody = ({
                 clipboard={clipboard}
                 setClipboard={setClipboard}
                 files={allFiles}
-                rootInfo={rootInfo}
               />
           }
           setSelectedContext={setSelectedContext}

--- a/src/navigator-card-body.jsx
+++ b/src/navigator-card-body.jsx
@@ -176,17 +176,16 @@ export const NavigatorCardBody = ({
     setHistory,
     setHistoryIndex,
     setSelected,
-    setSelectedContext,
     sortBy,
     loadingFiles,
     clipboard,
     setClipboard,
     addAlert,
     allFiles,
-    selectedContext,
     rootInfo,
 }) => {
     const [boxPerRow, setBoxPerRow] = useState(0);
+    const [selectedContext, setSelectedContext] = useState(null);
     const Dialogs = useDialogs();
     const sortedFiles = useMemo(() => {
         const compareFunc = compare(sortBy);
@@ -319,6 +318,12 @@ export const NavigatorCardBody = ({
         }
     };
 
+    const handleContextMenu = () => {
+        setSelectedContext(null);
+        const sel = path ? path[path.length - 1] : undefined;
+        setSelected([{ name: sel }]);
+    };
+
     const Item = ({ file }) => {
         const getFileType = (file) => {
             if (file.type === "dir") {
@@ -405,7 +410,11 @@ export const NavigatorCardBody = ({
         return (
             <>
                 {contextMenu}
-                <CardBody onClick={resetSelected} id="navigator-card-body">
+                <CardBody
+                  id="navigator-card-body"
+                  onClick={resetSelected}
+                  onContextMenu={handleContextMenu}
+                >
                     <Gallery id="folder-view">
                         {sortedFiles.map(file => <Item file={file} key={file.name} />)}
                     </Gallery>
@@ -422,6 +431,7 @@ export const NavigatorCardBody = ({
                   variant="compact"
                   columns={[_("Name")]}
                   rows={sortedFiles.map(file => ({ columns: [{ title: <Item file={file} key={file.name} /> }] }))}
+                  onContextMenu={handleContextMenu}
                 />
             </>
         );

--- a/src/navigator-card-body.jsx
+++ b/src/navigator-card-body.jsx
@@ -86,7 +86,7 @@ const compare = (sortBy) => {
 const ContextMenuItems = ({ path, currentDir, selected, selectedContext, setSelected, setHistory, setHistoryIndex, addAlert, rootInfo, clipboard, setClipboard, files }) => {
     const Dialogs = useDialogs();
 
-    const _createDirectory = () => createDirectory(Dialogs, currentDir, selectedContext || selected);
+    const _createDirectory = () => createDirectory(Dialogs, currentDir);
     const _createLink = () => createLink(Dialogs, currentDir, files, selectedContext);
     const _copyItem = () => {
         copyItem(setClipboard, selected.length > 1

--- a/src/navigator-card-body.jsx
+++ b/src/navigator-card-body.jsx
@@ -91,7 +91,7 @@ const ContextMenuItems = ({ path, currentDir, selected, selectedContext, setSele
     const _copyItem = () => {
         copyItem(setClipboard, selected.length > 1
             ? selected.map(s => currentDir + s.name)
-            : [currentDir + selectedContext.name]);
+            : [currentDir + selected[0].name]);
     };
     const _pasteItem = (targetPath, asSymlink) => pasteItem(clipboard, targetPath.join("/") + "/", asSymlink, addAlert);
     const _renameItem = () => renameItem(Dialogs, { selected: selectedContext, path, setHistory, setHistoryIndex });

--- a/src/sidebar.jsx
+++ b/src/sidebar.jsx
@@ -300,7 +300,7 @@ const DropdownWithKebab = ({
             ? [
                 {
                     id: "create-item",
-                    onClick: () => createDirectory(Dialogs, currentPath, selected),
+                    onClick: () => createDirectory(Dialogs, currentPath),
                     title: _("Create directory")
                 }
             ]

--- a/src/sidebar.jsx
+++ b/src/sidebar.jsx
@@ -315,9 +315,7 @@ const DropdownWithKebab = ({
             id: "edit-permissions",
             onClick: () => {
                 editPermissions(Dialogs, {
-                    selected: selected.length === 0
-                        ? null
-                        : selected[0],
+                    selected: selected[0] || currentDirectory,
                     path
                 });
             },

--- a/src/sidebar.jsx
+++ b/src/sidebar.jsx
@@ -330,25 +330,25 @@ const DropdownWithKebab = ({
             },
             title: _("Rename")
         },
-        { type: "divider" },
-        {
-            id: "delete-item",
-            onClick: () => {
-                deleteItem(Dialogs, {
-                    selected,
-                    itemPath: currentPath + (selected.length === 0
-                        ? ""
-                        : selected[0].name),
-                    path,
-                    setHistory,
-                    setHistoryIndex,
-                    setSelected,
-                    currentDirectory
-                });
-            },
-            title: _("Delete"),
-            className:"pf-m-danger"
-        },
+        ...selected.length !== 0
+            ? [
+                { type: "divider" },
+                {
+                    id: "delete-item",
+                    onClick: () => {
+                        deleteItem(Dialogs, {
+                            selected,
+                            path: currentPath,
+                            setHistory,
+                            setHistoryIndex,
+                            setSelected,
+                        });
+                    },
+                    title: _("Delete"),
+                    className:"pf-m-danger"
+                }
+            ]
+            : [],
     ];
 
     const multiDropdownOptions = [

--- a/test/check-application
+++ b/test/check-application
@@ -355,19 +355,6 @@ class TestNavigator(testlib.MachineCase):
         m.execute("sudo chattr -i /home/admin/newfile")
         self.delete_item(b, "file", "newfile")
 
-        # Delete current directory
-        m.execute("mkdir /home/admin/newdir")
-        b.wait_visible("[data-item='newdir']")
-        b.mouse("[data-item='newdir']", "dblclick")
-        b.wait_not_present("[data-item='newdir']")
-        b.click("#dropdown-menu")
-        b.click("#delete-item")
-        b.wait_in_text("h1.pf-v5-c-modal-box__title", "Delete directory newdir?")
-        b.click("button.pf-m-danger")
-        b.wait_text(".last-breadcrumb-button", "admin")
-        b.wait_in_text("#sidebar-card-header", "admin")
-        b.wait_not_present("[data-item='newdir']")
-
     def testCreate(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
This PR aims to move the ContextMenu into the NavigatorCardBody as it has no place in `app.jsx` plus remove the context menu related event listeners to the NavigatorCardBody and stop having a per Item event listener for the Context Menu.

This is now so far all preparation work, I have a patch to make it use on `onContextMenu` but that requires more work to handle the folder switching breaks contextMenu bug.