### PR TITLE
Prepare for re-usable contextmenu/dropdown items

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -121,6 +121,7 @@ export const Application = () => {
               currentDir={currentDir}
               setHistory={setHistory} history={history}
               historyIndex={historyIndex} setHistoryIndex={setHistoryIndex}
+              showHidden={showHidden} setShowHidden={setShowHidden}
             />
             <PageSection>
                 <Sidebar isPanelRight hasGutter>
@@ -180,7 +181,6 @@ export const Application = () => {
                           }
                           setHistory={setHistory} setHistoryIndex={setHistoryIndex}
                           showHidden={showHidden} setSelected={setSelected}
-                          setShowHidden={setShowHidden}
                           clipboard={clipboard} setClipboard={setClipboard}
                           files={files} addAlert={addAlert}
                         />

--- a/src/fileActions.jsx
+++ b/src/fileActions.jsx
@@ -98,8 +98,8 @@ export const editPermissions = (Dialogs, options) => {
     );
 };
 
-export const copyItem = (setClipboard, sourcePath) => {
-    setClipboard(sourcePath);
+export const copyItems = (setClipboard, sourcePaths) => {
+    setClipboard(sourcePaths);
 };
 
 export const pasteItem = (clipboard, targetPath, asSymlink, addAlert) => {

--- a/src/navigator-card-body.jsx
+++ b/src/navigator-card-body.jsx
@@ -88,11 +88,7 @@ const ContextMenuItems = ({ path, currentDir, selected, setSelected, setHistory,
 
     const _createDirectory = () => createDirectory(Dialogs, currentDir);
     const _createLink = () => createLink(Dialogs, currentDir, files, selected[0]);
-    const _copyItems = () => {
-        copyItems(setClipboard, selected.length > 1
-            ? selected.map(s => currentDir + s.name)
-            : [currentDir + selected[0].name]);
-    };
+    const _copyItems = () => copyItems(setClipboard, selected.map(s => currentDir + s.name));
     const _pasteItem = (targetPath, asSymlink) => pasteItem(clipboard, targetPath.join("/") + "/", asSymlink, addAlert);
     const _renameItem = () => renameItem(Dialogs, { selected: selected[0], path, setHistory, setHistoryIndex });
     const _editPermissions = () => editPermissions(Dialogs, { selected: selected[0], path });

--- a/src/navigator-card-body.jsx
+++ b/src/navigator-card-body.jsx
@@ -35,7 +35,7 @@ import { ListingTable } from "cockpit-components-table.jsx";
 
 import { ContextMenu } from "cockpit-components-context-menu.jsx";
 import {
-    copyItem, createDirectory, createLink, deleteItem, editPermissions, pasteItem, renameItem
+    copyItems, createDirectory, createLink, deleteItem, editPermissions, pasteItem, renameItem
 } from "./fileActions.jsx";
 
 const _ = cockpit.gettext;
@@ -88,8 +88,8 @@ const ContextMenuItems = ({ path, currentDir, selected, setSelected, setHistory,
 
     const _createDirectory = () => createDirectory(Dialogs, currentDir);
     const _createLink = () => createLink(Dialogs, currentDir, files, selected[0]);
-    const _copyItem = () => {
-        copyItem(setClipboard, selected.length > 1
+    const _copyItems = () => {
+        copyItems(setClipboard, selected.length > 1
             ? selected.map(s => currentDir + s.name)
             : [currentDir + selected[0].name]);
     };
@@ -134,7 +134,7 @@ const ContextMenuItems = ({ path, currentDir, selected, setSelected, setHistory,
         );
     } else if (selected.length === 1) {
         menuItems.push(
-            { title: _("Copy"), onClick: _copyItem },
+            { title: _("Copy"), onClick: _copyItems },
             ...(selected[0].type === "dir")
                 ? [
                     {
@@ -154,7 +154,7 @@ const ContextMenuItems = ({ path, currentDir, selected, setSelected, setHistory,
         );
     } else if (selected.length > 1) {
         menuItems.push(
-            { title: _("Copy"), onClick: _copyItem },
+            { title: _("Copy"), onClick: _copyItems },
             { title: _("Delete"), onClick: _deleteItem, className: "pf-m-danger" }
         );
     }

--- a/src/navigatorBreadcrumbs.jsx
+++ b/src/navigatorBreadcrumbs.jsx
@@ -17,12 +17,84 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 import cockpit from "cockpit";
-import React from "react";
+import React, { useState } from "react";
 
-import { Button, Flex, FlexItem, PageBreadcrumb } from "@patternfly/react-core";
-import { ArrowLeftIcon, ArrowRightIcon } from "@patternfly/react-icons";
+import {
+    Button,
+    Dropdown,
+    DropdownItem,
+    DropdownList,
+    Flex,
+    FlexItem,
+    PageBreadcrumb,
+    Icon,
+    MenuToggle,
+} from "@patternfly/react-core";
+import { ArrowLeftIcon, ArrowRightIcon, CheckIcon, EllipsisVIcon } from "@patternfly/react-icons";
 
-export const NavigatorBreadcrumbs = ({ currentDir, path, history, setHistory, historyIndex, setHistoryIndex }) => {
+const _ = cockpit.gettext;
+
+const SettingsDropdown = ({ showHidden, setShowHidden }) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const onToggleClick = () => setIsOpen(!isOpen);
+    const onSelect = (_event, _itemId) => setIsOpen(false);
+
+    const onToggleHidden = () => {
+        setShowHidden(showHidden => {
+            localStorage.setItem("cockpit-navigator.showHiddenFiles", !showHidden ? "true" : "false");
+            return !showHidden;
+        });
+    };
+
+    const showHiddenItems = (
+        <Flex justifyContent={{ default: "justifyContentSpaceBetween" }}>
+            <FlexItem>{_("Show hidden items")}</FlexItem>
+            <FlexItem>
+                {showHidden &&
+                <Icon size="sm">
+                    <CheckIcon className="check-icon" />
+                </Icon>}
+            </FlexItem>
+        </Flex>
+    );
+
+    return (
+        <Dropdown
+          isOpen={isOpen}
+          onSelect={onSelect}
+          onOpenChange={setIsOpen}
+          popperProps={{ position: "right" }}
+          toggle={toggleRef =>
+              <MenuToggle
+                ref={toggleRef} variant="plain"
+                onClick={onToggleClick} isExpanded={isOpen}
+                id="global-settings-menu"
+              >
+                  <EllipsisVIcon />
+              </MenuToggle>}
+        >
+            <DropdownList>
+                <DropdownItem
+                  id="show-hidden-items"
+                  onClick={onToggleHidden}
+                >
+                    {showHiddenItems}
+                </DropdownItem>
+            </DropdownList>
+        </Dropdown>
+    );
+};
+
+export const NavigatorBreadcrumbs = ({
+    currentDir,
+    path,
+    history,
+    setHistory,
+    historyIndex,
+    setHistoryIndex,
+    showHidden,
+    setShowHidden
+}) => {
     const navigateBack = () => {
         if (historyIndex > 0) {
             cockpit.location.go("/", { path: encodeURIComponent(history[historyIndex - 1].join("/")) });
@@ -80,6 +152,9 @@ export const NavigatorBreadcrumbs = ({ currentDir, path, history, setHistory, hi
                             );
                         })}
                     </Flex>
+                </FlexItem>
+                <FlexItem align={{ default: 'alignRight' }}>
+                    <SettingsDropdown showHidden={showHidden} setShowHidden={setShowHidden} />
                 </FlexItem>
             </Flex>
         </PageBreadcrumb>

--- a/src/sidebar.jsx
+++ b/src/sidebar.jsx
@@ -35,9 +35,6 @@ import {
     Dropdown,
     DropdownItem,
     DropdownList,
-    Flex,
-    FlexItem,
-    Icon,
     MenuToggle,
     Text,
     TextContent,
@@ -45,7 +42,6 @@ import {
 } from "@patternfly/react-core";
 
 import {
-    CheckIcon,
     EllipsisVIcon,
 } from "@patternfly/react-icons";
 
@@ -116,7 +112,6 @@ export const SidebarPanelDetails = ({
     setHistory,
     setHistoryIndex,
     setPath,
-    setShowHidden,
     showHidden,
     setSelected,
     currentDirectory,
@@ -168,8 +163,8 @@ export const SidebarPanelDetails = ({
                 </CardTitle>
                 <DropdownWithKebab
                   selected={selected} path={path}
-                  setPath={setPath} showHidden={showHidden}
-                  setShowHidden={setShowHidden} setHistory={setHistory}
+                  setPath={setPath}
+                  setHistory={setHistory}
                   setHistoryIndex={setHistoryIndex} files={files}
                   clipboard={clipboard} setClipboard={setClipboard}
                   setSelected={setSelected} currentDirectory={currentDirectory}
@@ -203,8 +198,6 @@ export const SidebarPanelDetails = ({
 const DropdownWithKebab = ({
     selected,
     path,
-    showHidden,
-    setShowHidden,
     setHistory,
     setHistoryIndex,
     files,
@@ -219,32 +212,9 @@ const DropdownWithKebab = ({
 
     const onToggleClick = () => setIsOpen(!isOpen);
     const onSelect = (_event, itemId) => setIsOpen(false);
-    const onToggleHidden = () => {
-        setShowHidden(showHidden => {
-            localStorage.setItem("cockpit-navigator.showHiddenFiles", !showHidden ? "true" : "false");
-            return !showHidden;
-        });
-    };
-
     const currentPath = path.join("/") + "/";
 
-    const showHiddenItems = (
-        <Flex justifyContent={{ default: "justifyContentSpaceBetween" }}>
-            <FlexItem>{_("Show hidden items")}</FlexItem>
-            <FlexItem>
-                {showHidden &&
-                <Icon size="sm">
-                    <CheckIcon className="check-icon" />
-                </Icon>}
-            </FlexItem>
-        </Flex>
-    );
-
     const singleDropdownOptions = [
-        ...selected.length === 0
-            ? [{ id: "show-hidden-items", onClick: onToggleHidden, title: showHiddenItems }]
-            : [],
-        { type: "divider" },
         ...selected.length === 1
             ? [
                 {

--- a/src/sidebar.jsx
+++ b/src/sidebar.jsx
@@ -244,15 +244,6 @@ const DropdownWithKebab = ({
         ...selected.length === 0
             ? [{ id: "show-hidden-items", onClick: onToggleHidden, title: showHiddenItems }]
             : [],
-        {
-            id: "copy-path",
-            onClick: () => {
-                navigator.clipboard.writeText(path.join("/") + "/" + (selected.length === 1
-                    ? selected[0].name
-                    : ""));
-            },
-            title: _("Copy full path")
-        },
         { type: "divider" },
         ...selected.length === 1
             ? [

--- a/src/sidebar.jsx
+++ b/src/sidebar.jsx
@@ -49,7 +49,7 @@ import * as timeformat from "timeformat";
 import { useDialogs } from "dialogs.jsx";
 
 import {
-    copyItem, createDirectory, createLink, deleteItem, editPermissions, pasteItem, renameItem
+    copyItems, createDirectory, createLink, deleteItem, editPermissions, pasteItem, renameItem
 } from "./fileActions.jsx";
 import { get_permissions } from "./common";
 
@@ -219,7 +219,7 @@ const DropdownWithKebab = ({
             ? [
                 {
                     id: "copy-item",
-                    onClick: () => copyItem(setClipboard, [path.join("/") + "/" + selected[0].name]),
+                    onClick: () => copyItems(setClipboard, [path.join("/") + "/" + selected[0].name]),
                     title: _("Copy"),
                 }
             ]
@@ -313,7 +313,7 @@ const DropdownWithKebab = ({
     const multiDropdownOptions = [
         {
             id: "copy-item",
-            onClick: () => copyItem(setClipboard, selected.map(s => path.join("/") + "/" + s.name)),
+            onClick: () => copyItems(setClipboard, selected.map(s => path.join("/") + "/" + s.name)),
             title: _("Copy")
         },
         {

--- a/test/check-application
+++ b/test/check-application
@@ -507,7 +507,7 @@ class TestNavigator(testlib.MachineCase):
         b.wait_in_text("#sidebar-card-header", "2 items (1 hidden)")
 
         # Show hidden items
-        b.click("#dropdown-menu")
+        b.click("#global-settings-menu")
         b.click("#show-hidden-items")
         b.wait_visible("[data-item='f1']")
         b.wait_visible("[data-item='.f2']")
@@ -518,11 +518,6 @@ class TestNavigator(testlib.MachineCase):
         b.enter_page("/navigator")
         b.wait_visible("[data-item='f1']")
         b.wait_visible("[data-item='.f2']")
-
-        # Button shouldn't be visible when a file is selected
-        b.click("[data-item='f1']")
-        b.click("#dropdown-menu")
-        b.wait_not_present("#show-hidden-items")
 
     def testCreateLink(self):
         b = self.browser

--- a/test/check-application
+++ b/test/check-application
@@ -150,35 +150,6 @@ class TestNavigator(testlib.MachineCase):
         # sidebar is reset when files are removed
         b.wait_in_text("#sidebar-card-header", "admin")
 
-        # Firefox does not support setting of permissions
-        # and therefore we cannot test copy/paste with context menu
-        if b.cdp.browser.name != "firefox":
-            try:
-                b.grant_permissions("clipboardReadWrite", "clipboardSanitizedWrite")
-            except RuntimeError:
-                # fallback for older Chrome releases
-                b.grant_permissions("clipboardRead", "clipboardWrite")
-
-            # Copy current path
-            b.click("button[aria-label='Display as a grid']")
-            b.click("#dropdown-menu")
-            b.click("#copy-path")
-            # Paste text in filter input to check copied text
-            b.focus("input[placeholder='Filter directory']")
-            b.key_press("v", 2)
-            b.wait_val("input[placeholder='Filter directory']", "/home/admin/")
-            b.key_press(["\b"] * 12)
-
-            # Copy item path
-            b.click("[data-item='not-hidden']")
-            b.click("#dropdown-menu")
-            b.click("#copy-path")
-            # Paste text in filter input to check copied text
-            b.focus("input[placeholder='Filter directory']")
-            b.key_press("v", 2)
-            b.wait_val("input[placeholder='Filter directory']", "/home/admin/not-hidden")
-            b.set_input_text("input[placeholder='Filter directory']", "")
-
         # List root directory
         # Click "/" on the breadcrumb
         b.click(".breadcrumb-button:nth-of-type(1)")


### PR DESCRIPTION
Prepare for the contextmenu and the dropdown menu to be merged together into one component. For this to happen drop everything not required from the sidebar menu.

After that we need to fix the insanity which is the current selected state. Right clicking sets the current path into state while the sidebar just assumes it acts on the current dir. Once that is refactored we can combine the actions into one and drop a ton of duplicate code.

New UI:

![image](https://github.com/cockpit-project/cockpit-navigator/assets/67428/22bfe054-5ca9-4adb-938e-535c5744ed6b)
