### PR TITLE
Drop currentDir where possible

### DIFF
--- a/src/apis/spawnHelpers.jsx
+++ b/src/apis/spawnHelpers.jsx
@@ -24,10 +24,10 @@ import { ForceDeleteModal } from "../fileActions";
 
 const options = { err: "message", superuser: "try" };
 
-const renameCommand = ({ selected, path, name }) => {
-    return selected.items_cnt
-        ? ["mv", path.join("/"), path.slice(0, -1).join("/") + "/" + name]
-        : ["mv", path.join("/") + "/" + selected.name, path.join("/") + "/" + name];
+const renameCommand = (selected, path, newPath, is_current_dir) => {
+    return is_current_dir
+        ? ["mv", path.join("/"), newPath]
+        : ["mv", path.join("/") + "/" + selected.name, newPath];
 };
 
 export const spawnDeleteItem = ({ path, selected, Dialogs, setSelected, setHistory, setHistoryIndex }) => {
@@ -71,13 +71,15 @@ export const spawnForceDelete = ({ selected, path, Dialogs, setDeleteFailed, set
 };
 
 export const spawnRenameItem = ({ selected, name, path, Dialogs, setErrorMessage, setHistory, setHistoryIndex }) => {
-    const newPath = selected.items_cnt
+    console.log(selected);
+    const is_current_dir = path.at(-1) === selected.name;
+    const newPath = is_current_dir
         ? path.slice(0, -1).join("/") + "/" + name
         : path.join("/") + "/" + name;
 
-    cockpit.spawn(renameCommand({ selected, path, name }), options)
+    cockpit.spawn(renameCommand(selected, path, newPath, is_current_dir), options)
             .then(() => {
-                if (selected.items_cnt) {
+                if (is_current_dir) {
                     cockpit.location.go("/", { path: encodeURIComponent(newPath) });
                     setHistory(h => h.slice(0, -1));
                     setHistoryIndex(i => i - 1);

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -118,7 +118,6 @@ export const Application = () => {
         <Page>
             <NavigatorBreadcrumbs
               path={path}
-              currentDir={currentDir}
               setHistory={setHistory} history={history}
               historyIndex={historyIndex} setHistoryIndex={setHistoryIndex}
               showHidden={showHidden} setShowHidden={setShowHidden}

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -84,7 +84,7 @@ export const Application = () => {
             }
 
             const info = fsinfo(
-                `/${currentDir}`,
+                `/${currentPath}`,
                 ["type", "mode", "size", "mtime", "user", "group", "target", "entries", "targets"]
             );
             return info.effect(state => {
@@ -101,7 +101,7 @@ export const Application = () => {
                 setFiles(files);
             });
         },
-        [currentDir, sel]
+        [currentPath, sel]
     );
 
     if (loading)

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -169,15 +169,6 @@ export const Application = () => {
                         <SidebarPanelDetails
                           path={path}
                           selected={selected.map(s => files.find(f => f.name === s.name)).filter(s => s !== undefined)}
-                          currentDirectory={
-                              {
-                                  name: path[path.length - 1],
-                                  items_cnt: {
-                                      all: files.length,
-                                      hidden: files.length - files.filter(file => !file.name.startsWith(".")).length
-                                  }
-                              }
-                          }
                           setHistory={setHistory} setHistoryIndex={setHistoryIndex}
                           showHidden={showHidden} setSelected={setSelected}
                           clipboard={clipboard} setClipboard={setClipboard}

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -171,7 +171,6 @@ export const Application = () => {
                           selected={selected.map(s => files.find(f => f.name === s.name)).filter(s => s !== undefined)}
                           currentDirectory={
                               {
-                                  has_error: errorMessage,
                                   name: path[path.length - 1],
                                   items_cnt: {
                                       all: files.length,

--- a/src/fileActions.jsx
+++ b/src/fileActions.jsx
@@ -124,7 +124,7 @@ export const ConfirmDeletionDialog = ({
             modalTitle = cockpit.format(_("Delete file $0?"), selectedItem.name);
         } else if (selectedItem.type === "lnk") {
             modalTitle = cockpit.format(_("Delete link $0?"), selectedItem.name);
-        } else if (selectedItem.type === "dir" || selectedItem.items_cnt) {
+        } else if (selectedItem.type === "dir") {
             modalTitle = cockpit.format(_("Delete directory $0?"), selectedItem.name);
         } else {
             modalTitle = cockpit.format(_("Delete $0?"), selectedItem.name);
@@ -169,7 +169,7 @@ export const ForceDeleteModal = ({ selected, path, initialError }) => {
             modalTitle = cockpit.format(_("Force delete file $0?"), selectedItem.name);
         } else if (selectedItem.type === "lnk") {
             modalTitle = cockpit.format(_("Force delete link $0?"), selectedItem.name);
-        } else if (selectedItem.type === "dir" || selectedItem.items_cnt) {
+        } else if (selectedItem.type === "dir") {
             modalTitle = cockpit.format(_("Force delete directory $0?"), selectedItem.name);
         } else {
             modalTitle = _("Force delete $0?", selectedItem.name);
@@ -272,7 +272,7 @@ export const RenameItemModal = ({ path, selected, setHistory, setHistoryIndex })
         title = cockpit.format(_("Rename file $0"), selected.name);
     } else if (selected.type === "lnk") {
         title = cockpit.format(_("Rename link $0"), selected.name);
-    } else if (selected.type === "dir" || selected.items_cnt) {
+    } else if (selected.type === "dir") {
         title = cockpit.format(_("Rename directory $0"), selected.name);
     } else {
         title = _("Rename $0", selected.name);

--- a/src/navigatorBreadcrumbs.jsx
+++ b/src/navigatorBreadcrumbs.jsx
@@ -86,14 +86,13 @@ const SettingsDropdown = ({ showHidden, setShowHidden }) => {
 };
 
 export const NavigatorBreadcrumbs = ({
-    currentDir,
     path,
     history,
     setHistory,
     historyIndex,
     setHistoryIndex,
     showHidden,
-    setShowHidden
+    setShowHidden,
 }) => {
     const navigateBack = () => {
         if (historyIndex > 0) {

--- a/src/sidebar.jsx
+++ b/src/sidebar.jsx
@@ -114,7 +114,6 @@ export const SidebarPanelDetails = ({
     setPath,
     showHidden,
     setSelected,
-    currentDirectory,
     clipboard,
     setClipboard,
     addAlert
@@ -132,9 +131,9 @@ export const SidebarPanelDetails = ({
     }, [path, selected]);
 
     const Dialogs = useDialogs();
-    const hidden_count = currentDirectory.items_cnt.hidden;
-    let shown_items = cockpit.format(cockpit.ngettext("$0 item", "$0 items", currentDirectory.items_cnt.all),
-                                     currentDirectory.items_cnt.all);
+    const directory_name = path[path.length - 1];
+    const hidden_count = files.filter(file => file.name.startsWith(".")).length;
+    let shown_items = cockpit.format(cockpit.ngettext("$0 item", "$0 items", files.length), files.length);
     if (!showHidden)
         shown_items += " " + cockpit.format(cockpit.ngettext("($0 hidden)", "($0 hidden)", hidden_count), hidden_count);
 
@@ -145,7 +144,7 @@ export const SidebarPanelDetails = ({
                     <TextContent>
                         <Text component={TextVariants.h2}>{selected.length === 1
                             ? selected[0].name
-                            : currentDirectory.name}
+                            : directory_name}
                         </Text>
                         {selected.length === 0 &&
                             <Text component={TextVariants.small}>
@@ -167,7 +166,7 @@ export const SidebarPanelDetails = ({
                   setHistory={setHistory}
                   setHistoryIndex={setHistoryIndex} files={files}
                   clipboard={clipboard} setClipboard={setClipboard}
-                  setSelected={setSelected} currentDirectory={currentDirectory}
+                  setSelected={setSelected}
                   addAlert={addAlert}
                 />
             </CardHeader>
@@ -204,11 +203,11 @@ const DropdownWithKebab = ({
     clipboard,
     setClipboard,
     setSelected,
-    currentDirectory,
     addAlert
 }) => {
     const Dialogs = useDialogs();
     const [isOpen, setIsOpen] = useState(false);
+    const directory_name = path[path.length - 1];
 
     const onToggleClick = () => setIsOpen(!isOpen);
     const onSelect = (_event, itemId) => setIsOpen(false);
@@ -276,7 +275,7 @@ const DropdownWithKebab = ({
             id: "edit-permissions",
             onClick: () => {
                 editPermissions(Dialogs, {
-                    selected: selected[0] || currentDirectory,
+                    selected: selected[0] || { name: directory_name, type: "dir" },
                     path
                 });
             },
@@ -285,7 +284,12 @@ const DropdownWithKebab = ({
         {
             id: "rename-item",
             onClick: () => {
-                renameItem(Dialogs, { selected: selected[0] || currentDirectory, path, setHistory, setHistoryIndex });
+                renameItem(Dialogs, {
+                    selected: selected[0] || { name: directory_name, type: "dir" },
+                    path,
+                    setHistory,
+                    setHistoryIndex
+                });
             },
             title: _("Rename")
         },

--- a/src/sidebar.jsx
+++ b/src/sidebar.jsx
@@ -147,7 +147,7 @@ export const SidebarPanelDetails = ({
                             ? selected[0].name
                             : currentDirectory.name}
                         </Text>
-                        {selected.length === 0 && !currentDirectory.has_error &&
+                        {selected.length === 0 &&
                             <Text component={TextVariants.small}>
                                 {shown_items}
                             </Text>}


### PR DESCRIPTION
This drops currentDir where possible except in the navigatorCardBody, it can be dropped there after we merge https://github.com/cockpit-project/cockpit-navigator/pull/254

An alternative approach is maybe to add `src/utils.ts` and then add a helper called `getCurrentDir(path: []string) => string` for looking up the directory name.