### PR TITLE
workflows: Bump action-release to get github-script@v7

### DIFF
--- a/.github/workflows/release.yml.disabled
+++ b/.github/workflows/release.yml.disabled
@@ -29,6 +29,6 @@ jobs:
         run: make dist
 
       - name: Publish GitHub release
-        uses: cockpit-project/action-release@88d994da62d1451c7073e26748c18413fcdf46e9
+        uses: cockpit-project/action-release@7d2e2657382e8d34f88a24b5987f2b81ea165785
         with:
           filename: "TARNAME-${{ github.ref_name }}.tar.xz"


### PR DESCRIPTION
This gets rid of the obsolete node.js 16. See
https://github.com/cockpit-project/action-release/commit/7d2e2657382e8

---

This isn't actually active yet, but let's bump it now so that we don't forget.