### PR TITLE
Unify menus cleanups

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -70,7 +70,6 @@ export const Application = () => {
     // the function itself is not expensive, but `path` is later used in expensive computation
     // and changing its reference value on every render causes performance issues
     const path = useMemo(() => currentPath?.split("/"), [currentPath]);
-    const currentDir = path.join("/") + "/";
     const sel = (
         options.path !== undefined
             ? path[path.length - 1]
@@ -163,7 +162,6 @@ export const Application = () => {
                             <NavigatorCardBody
                               currentFilter={currentFilter} files={visibleFiles}
                               path={path}
-                              currentDir={currentDir}
                               isGrid={isGrid} sortBy={sortBy}
                               selected={selected} setSelected={setSelected}
                               loadingFiles={loadingFiles}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -70,11 +70,6 @@ export const Application = () => {
     // the function itself is not expensive, but `path` is later used in expensive computation
     // and changing its reference value on every render causes performance issues
     const path = useMemo(() => currentPath?.split("/"), [currentPath]);
-    const sel = (
-        options.path !== undefined
-            ? path[path.length - 1]
-            : undefined
-    );
 
     useEffect(() => {
         cockpit.user().then(user => {
@@ -86,7 +81,7 @@ export const Application = () => {
 
     useEffect(
         () => {
-            if (sel === undefined) {
+            if (options.path === undefined) {
                 return;
             }
 
@@ -108,7 +103,7 @@ export const Application = () => {
                 setFiles(files);
             });
         },
-        [currentPath, sel]
+        [options, currentPath]
     );
 
     // the files in DOM are rendered from this list, creating a new array on

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -106,14 +106,6 @@ export const Application = () => {
         [options, currentPath]
     );
 
-    // the files in DOM are rendered from this list, creating a new array on
-    // every render can cause performance issues, so memoize it.
-    const visibleFiles = useMemo(() => {
-        return !showHidden
-            ? files.filter(file => !file.name.startsWith("."))
-            : files;
-    }, [files, showHidden]);
-
     if (loading)
         return <EmptyStatePanel loading />;
 
@@ -155,7 +147,7 @@ export const Application = () => {
                             />
                             {errorMessage && <EmptyStatePanel paragraph={errorMessage} icon={ExclamationCircleIcon} />}
                             <NavigatorCardBody
-                              currentFilter={currentFilter} files={visibleFiles}
+                              currentFilter={currentFilter} files={files}
                               path={path}
                               isGrid={isGrid} sortBy={sortBy}
                               selected={selected} setSelected={setSelected}
@@ -163,7 +155,7 @@ export const Application = () => {
                               clipboard={clipboard}
                               setClipboard={setClipboard}
                               addAlert={addAlert}
-                              allFiles={files}
+                              showHidden={showHidden}
                             />
                         </Card>
                     </SidebarContent>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -130,6 +130,22 @@ export const Application = () => {
 
     return (
         <Page>
+            <AlertGroup isToast isLiveRegion>
+                {alerts.map(alert => (
+                    <Alert
+                      variant={alert.variant}
+                      title={alert.title}
+                      actionClose={
+                          <AlertActionCloseButton
+                            title={alert.title}
+                            variantLabel={`${alert.variant} alert`}
+                            onClose={() => removeAlert(alert.key)}
+                          />
+                      }
+                      key={alert.key}
+                    />
+                ))}
+            </AlertGroup>
             <NavigatorBreadcrumbs
               path={path}
               showHidden={showHidden} setShowHidden={setShowHidden}
@@ -156,22 +172,6 @@ export const Application = () => {
                               addAlert={addAlert}
                               allFiles={files}
                             />
-                            <AlertGroup isToast isLiveRegion>
-                                {alerts.map(alert => (
-                                    <Alert
-                                      variant={alert.variant}
-                                      title={alert.title}
-                                      actionClose={
-                                          <AlertActionCloseButton
-                                            title={alert.title}
-                                            variantLabel={`${alert.variant} alert`}
-                                            onClose={() => removeAlert(alert.key)}
-                                          />
-                                      }
-                                      key={alert.key}
-                                    />
-                                ))}
-                            </AlertGroup>
                         </Card>
                     </SidebarContent>
                     <SidebarPanel className="sidebar-panel" width={{ default: "width_25" }}>

--- a/src/navigator-card-body.jsx
+++ b/src/navigator-card-body.jsx
@@ -288,13 +288,10 @@ export const NavigatorCardBody = ({
 
     const resetSelected = e => {
         if (e.target.id === "folder-view" || e.target.id === "navigator-card-body") {
-            setSelected([]);
+            if (selected.length !== 0) {
+                setSelected([]);
+            }
         }
-    };
-
-    const handleContextMenu = () => {
-        const sel = path ? path[path.length - 1] : undefined;
-        setSelected([{ name: sel }]);
     };
 
     if (loadingFiles)
@@ -325,7 +322,7 @@ export const NavigatorCardBody = ({
                 <CardBody
                   id="navigator-card-body"
                   onClick={resetSelected}
-                  onContextMenu={handleContextMenu}
+                  onContextMenu={resetSelected}
                 >
                     <Gallery id="folder-view">
                         {sortedFiles.map(file =>
@@ -344,6 +341,8 @@ export const NavigatorCardBody = ({
             <>
                 {contextMenu}
                 <ListingTable
+                  onClick={resetSelected}
+                  onContextMenu={resetSelected}
                   id="folder-view"
                   className="pf-m-no-border-rows"
                   variant="compact"
@@ -362,7 +361,6 @@ export const NavigatorCardBody = ({
                           }
                       ]
                   }))}
-                  onContextMenu={handleContextMenu}
                 />
             </>
         );

--- a/src/navigator-card-body.jsx
+++ b/src/navigator-card-body.jsx
@@ -83,8 +83,9 @@ const compare = (sortBy) => {
 };
 
 // eslint-disable-next-line max-len
-const ContextMenuItems = ({ path, currentDir, selected, setSelected, addAlert, clipboard, setClipboard, files }) => {
+const ContextMenuItems = ({ path, selected, setSelected, addAlert, clipboard, setClipboard, files }) => {
     const Dialogs = useDialogs();
+    const currentDir = path.join("/") + "/";
 
     const _createDirectory = () => createDirectory(Dialogs, currentDir);
     const _createLink = () => createLink(Dialogs, currentDir, files, selected[0]);
@@ -171,7 +172,6 @@ const ContextMenuItems = ({ path, currentDir, selected, setSelected, addAlert, c
 };
 
 export const NavigatorCardBody = ({
-    currentDir,
     currentFilter,
     files,
     isGrid,
@@ -308,7 +308,6 @@ export const NavigatorCardBody = ({
         <ContextMenu parentId="folder-view">
             <ContextMenuItems
               path={path}
-              currentDir={currentDir}
               selected={selected}
               setSelected={setSelected}
               addAlert={addAlert}

--- a/src/navigator-card-body.jsx
+++ b/src/navigator-card-body.jsx
@@ -114,20 +114,18 @@ export const NavigatorCardBody = ({
     loadingFiles,
     clipboard,
     setClipboard,
+    showHidden,
     addAlert,
-    allFiles,
 }) => {
     const [boxPerRow, setBoxPerRow] = useState(0);
     const Dialogs = useDialogs();
-    const sortedFiles = useMemo(() => {
-        const compareFunc = compare(sortBy);
 
+    const sortedFiles = useMemo(() => {
         return files
-                .filter(file => {
-                    return file.name.toLowerCase().includes(currentFilter.toLowerCase());
-                })
-                .sort(compareFunc);
-    }, [files, currentFilter, sortBy]);
+                .filter(file => showHidden ? true : !file.name.startsWith("."))
+                .filter(file => file.name.toLowerCase().includes(currentFilter.toLowerCase()))
+                .sort(compare(sortBy));
+    }, [files, showHidden, currentFilter, sortBy]);
     const isMounted = useRef(null);
 
     function calculateBoxPerRow () {
@@ -242,7 +240,7 @@ export const NavigatorCardBody = ({
               addAlert={addAlert}
               clipboard={clipboard}
               setClipboard={setClipboard}
-              files={allFiles}
+              files={files}
             />
         </ContextMenu>
     );

--- a/test/check-application
+++ b/test/check-application
@@ -446,6 +446,8 @@ class TestNavigator(testlib.MachineCase):
         self.enter_navigator()
 
         # validation
+        m.execute("touch /home/admin/newfile")
+        b.click("[data-item='newfile']")
         b.click("#dropdown-menu")
         b.click("#rename-item")
         b.set_input_text("#rename-item-input", "test")
@@ -461,7 +463,6 @@ class TestNavigator(testlib.MachineCase):
         b.click(".pf-v5-c-modal-box__footer button.pf-m-link")  # cancel
 
         # Rename file
-        m.execute("touch /home/admin/newfile")
         self.rename_item(b, "newfile", "newfile1")
         b.wait_visible("[data-item='newfile1']")
         m.execute("rm /home/admin/newfile1")
@@ -475,26 +476,13 @@ class TestNavigator(testlib.MachineCase):
         self.rename_item(b, "newdir1", "new dir1")
         b.wait_visible("[data-item='new dir1']")
 
-        # Rename current folder
-        b.mouse("[data-item='new dir1']", "dblclick")
-        b.click("#dropdown-menu")
-        b.click("#rename-item")
-        b.wait_in_text("h1.pf-v5-c-modal-box__title", "Rename")
-        b.set_input_text("#rename-item-input", "newdir2")
-        b.click("button.pf-m-primary")
-        b.wait_in_text("#sidebar-card-header", "newdir2")
-        b.wait_text(self.last_breadcrumb_sel(), "newdir2")
-
-        # Go back to home folder
-        b.click(".breadcrumb-button:nth-of-type(3)")
-
         # Renaming protected item should give an error
-        m.execute("sudo chattr +i /home/admin/newdir2")
-        self.rename_item(b, "newdir2", "testdir")
-        alert_text = "mv: cannot move '/home/admin/newdir2' to '/home/admin/testdir': Operation not permitted"
+        m.execute("sudo chattr +i /home/admin/new\\ dir1")
+        self.rename_item(b, "new dir1", "testdir")
+        alert_text = "mv: cannot move '/home/admin/new dir1' to '/home/admin/testdir': Operation not permitted"
         self.wait_modal_inline_alert(b, alert_text)
         b.click("div.pf-v5-c-modal-box__close")
-        m.execute("sudo chattr -i /home/admin/newdir2")
+        m.execute("sudo chattr -i /home/admin/new\\ dir1")
 
     def testHiddenItems(self):
         b = self.browser


### PR DESCRIPTION
Merge the two menu's into one helper function, this reduces a ton of code duplication, simplifies and unifies everything. As side-effect removes renaming the current directory.