### PR TITLE
Split up folder state

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -21,7 +21,6 @@ import cockpit from "cockpit";
 import { superuser } from "superuser";
 import React, { useEffect, useMemo, useState } from "react";
 import {
-    Card,
     Page, PageSection,
     Sidebar, SidebarPanel, SidebarContent,
     AlertGroup, Alert, AlertVariant, AlertActionCloseButton
@@ -30,9 +29,8 @@ import { ExclamationCircleIcon } from "@patternfly/react-icons";
 
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 import { NavigatorBreadcrumbs } from "./navigator-breadcrumbs";
-import { NavigatorCardBody } from "./navigator-card-body.jsx";
 import { SidebarPanelDetails } from "./sidebar.jsx";
-import { NavigatorCardHeader } from "./header.jsx";
+import { NavigatorFolderView } from "./navigator-folder-view";
 import { usePageLocation } from "hooks.js";
 import { fsinfo, FileInfo } from "./fsinfo";
 
@@ -44,7 +42,7 @@ interface Alert {
     variant: AlertVariant,
 }
 
-interface NavigatorFileInfo extends FileInfo {
+export interface NavigatorFileInfo extends FileInfo {
     name: string,
     to: string | null,
 }
@@ -54,18 +52,14 @@ export const Application = () => {
     const [loading, setLoading] = useState(true);
     const [loadingFiles, setLoadingFiles] = useState(true);
     const [errorMessage, setErrorMessage] = useState("");
-    const [currentFilter, setCurrentFilter] = useState("");
     const [files, setFiles] = useState<NavigatorFileInfo[]>([]);
     // eslint-disable-next-line no-unused-vars
     const [rootInfo, setRootInfo] = useState<FileInfo | null>();
-    const [isGrid, setIsGrid] = useState(true);
-    const [sortBy, setSortBy] = useState(localStorage.getItem("cockpit-navigator.sort") || "az");
     const [selected, setSelected] = useState<NavigatorFileInfo[]>([]);
     const [showHidden, setShowHidden] = useState(localStorage.getItem("cockpit-navigator.showHiddenFiles") === "true");
-    const [clipboard, setClipboard] = useState([]);
+    const [clipboard, setClipboard] = useState<string[]>([]);
     const [alerts, setAlerts] = useState<Alert[]>([]);
 
-    const onFilterChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => setCurrentFilter(value);
     const currentPath = decodeURIComponent(options.path?.toString() || "");
     // the function itself is not expensive, but `path` is later used in expensive computation
     // and changing its reference value on every render causes performance issues
@@ -139,31 +133,19 @@ export const Application = () => {
             <PageSection>
                 <Sidebar isPanelRight hasGutter>
                     <SidebarContent>
-                        <Card>
-                            <NavigatorCardHeader
-                              currentFilter={currentFilter}
-                              onFilterChange={onFilterChange}
-                              isGrid={isGrid}
-                              setIsGrid={setIsGrid}
-                              sortBy={sortBy}
-                              setSortBy={setSortBy}
-                            />
-                            {errorMessage && <EmptyStatePanel paragraph={errorMessage} icon={ExclamationCircleIcon} />}
-                            <NavigatorCardBody
-                              files={files}
-                              currentFilter={currentFilter}
-                              path={path}
-                              isGrid={isGrid}
-                              sortBy={sortBy}
-                              selected={selected}
-                              setSelected={setSelected}
-                              loadingFiles={loadingFiles}
-                              clipboard={clipboard}
-                              setClipboard={setClipboard}
-                              addAlert={addAlert}
-                              showHidden={showHidden}
-                            />
-                        </Card>
+                        {errorMessage && <EmptyStatePanel paragraph={errorMessage} icon={ExclamationCircleIcon} />}
+                        {!errorMessage &&
+                        <NavigatorFolderView
+                          path={path}
+                          files={files}
+                          loadingFiles={loadingFiles}
+                          showHidden={showHidden}
+                          selected={selected}
+                          setSelected={setSelected}
+                          clipboard={clipboard}
+                          setClipboard={setClipboard}
+                          addAlert={addAlert}
+                        />}
                     </SidebarContent>
                     <SidebarPanel className="sidebar-panel" width={{ default: "width_25" }}>
                         <SidebarPanelDetails

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -62,7 +62,7 @@ export const Application = () => {
     const [sortBy, setSortBy] = useState(localStorage.getItem("cockpit-navigator.sort") || "az");
     const [selected, setSelected] = useState<NavigatorFileInfo[]>([]);
     const [showHidden, setShowHidden] = useState(localStorage.getItem("cockpit-navigator.showHiddenFiles") === "true");
-    const [clipboard, setClipboard] = useState(undefined);
+    const [clipboard, setClipboard] = useState([]);
     const [alerts, setAlerts] = useState<Alert[]>([]);
 
     const onFilterChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => setCurrentFilter(value);

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -141,16 +141,22 @@ export const Application = () => {
                     <SidebarContent>
                         <Card>
                             <NavigatorCardHeader
-                              currentFilter={currentFilter} onFilterChange={onFilterChange}
-                              isGrid={isGrid} setIsGrid={setIsGrid}
-                              sortBy={sortBy} setSortBy={setSortBy}
+                              currentFilter={currentFilter}
+                              onFilterChange={onFilterChange}
+                              isGrid={isGrid}
+                              setIsGrid={setIsGrid}
+                              sortBy={sortBy}
+                              setSortBy={setSortBy}
                             />
                             {errorMessage && <EmptyStatePanel paragraph={errorMessage} icon={ExclamationCircleIcon} />}
                             <NavigatorCardBody
-                              currentFilter={currentFilter} files={files}
+                              files={files}
+                              currentFilter={currentFilter}
                               path={path}
-                              isGrid={isGrid} sortBy={sortBy}
-                              selected={selected} setSelected={setSelected}
+                              isGrid={isGrid}
+                              sortBy={sortBy}
+                              selected={selected}
+                              setSelected={setSelected}
                               loadingFiles={loadingFiles}
                               clipboard={clipboard}
                               setClipboard={setClipboard}

--- a/src/fileActions.jsx
+++ b/src/fileActions.jsx
@@ -549,13 +549,13 @@ export const fileActions = (path, files, selected, setSelected, clipboard, setCl
                 id: "paste-item",
                 title: _("Paste"),
                 onClick: () => spawnPaste(clipboard, currentPath, false, addAlert),
-                isDisabled: clipboard === undefined
+                isDisabled: clipboard.length === 0
             },
             {
                 id: "paste-as-symlink",
                 title: _("Paste as symlink"),
                 onClick: () => spawnPaste(clipboard, currentPath, true, addAlert),
-                isDisabled: clipboard === undefined
+                isDisabled: clipboard.length === 0
             },
             { type: "divider" },
             {
@@ -588,7 +588,7 @@ export const fileActions = (path, files, selected, setSelected, clipboard, setCl
                         id: "paste-into-directory",
                         title: _("Paste into directory"),
                         onClick: () => spawnPaste(clipboard, [currentPath + selected[0].name], false, addAlert),
-                        isDisabled: clipboard === undefined
+                        isDisabled: clipboard.length === 0
                     }
                 ]
                 : [],

--- a/src/navigator-folder-view.tsx
+++ b/src/navigator-folder-view.tsx
@@ -1,0 +1,79 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { useState } from "react";
+import { AlertVariant, Card } from "@patternfly/react-core";
+
+import { NavigatorFileInfo } from "./app";
+import { NavigatorCardBody } from "./navigator-card-body.jsx";
+import { NavigatorCardHeader } from "./header.jsx";
+
+export const NavigatorFolderView = ({
+    path,
+    files,
+    loadingFiles,
+    showHidden,
+    selected,
+    setSelected,
+    clipboard,
+    setClipboard,
+    addAlert,
+}: {
+    path: string[],
+    files: NavigatorFileInfo[],
+    loadingFiles: boolean,
+    showHidden: boolean,
+    selected: NavigatorFileInfo[],
+    setSelected: React.Dispatch<React.SetStateAction<NavigatorFileInfo[]>>,
+    clipboard: string[],
+    setClipboard: React.Dispatch<React.SetStateAction<string[]>>,
+    addAlert: (title: string, variant: AlertVariant, key: string) => void,
+}) => {
+    const [currentFilter, setCurrentFilter] = useState("");
+    const [isGrid, setIsGrid] = useState(true);
+    const [sortBy, setSortBy] = useState(localStorage.getItem("cockpit-navigator.sort") || "az");
+    const onFilterChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => setCurrentFilter(value);
+
+    return (
+        <Card>
+            <NavigatorCardHeader
+              currentFilter={currentFilter}
+              onFilterChange={onFilterChange}
+              isGrid={isGrid}
+              setIsGrid={setIsGrid}
+              sortBy={sortBy}
+              setSortBy={setSortBy}
+            />
+            <NavigatorCardBody
+              files={files}
+              currentFilter={currentFilter}
+              path={path}
+              isGrid={isGrid}
+              sortBy={sortBy}
+              selected={selected}
+              setSelected={setSelected}
+              loadingFiles={loadingFiles}
+              clipboard={clipboard}
+              setClipboard={setClipboard}
+              addAlert={addAlert}
+              showHidden={showHidden}
+            />
+        </Card>
+    );
+};


### PR DESCRIPTION
With moving the Folder related sorting/filtering into a new component this cleans up app.tsx nicely and also keeps errorMessage in app.tsx.

Some further ideas:

* Get rid of `loadingFiles`, should we just pass `rootInfo`? And with that determine if we should show the spinner?
* The whole Sidebar has selected state which is kinda annoying! We could do this trick again and move Sidebar and Folderview into a component. But that might not be worth it
* clipboard and addAlert get's passed too deep, maybe a contextprovider would be suitable.