### PR TITLE
Remember localStorage settings after logout

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -56,7 +56,7 @@ export const Application = () => {
     // eslint-disable-next-line no-unused-vars
     const [rootInfo, setRootInfo] = useState<FileInfo | null>();
     const [selected, setSelected] = useState<NavigatorFileInfo[]>([]);
-    const [showHidden, setShowHidden] = useState(localStorage.getItem("cockpit-navigator.showHiddenFiles") === "true");
+    const [showHidden, setShowHidden] = useState(localStorage.getItem("navigator:showHiddenFiles") === "true");
     const [clipboard, setClipboard] = useState<string[]>([]);
     const [alerts, setAlerts] = useState<Alert[]>([]);
 

--- a/src/header.jsx
+++ b/src/header.jsx
@@ -68,7 +68,7 @@ const ViewSelector = ({ isGrid, setIsGrid, sortBy, setSortBy }) => {
     const onSelect = (ev, itemId) => {
         setIsOpen(false);
         setSortBy(itemId);
-        localStorage.setItem("cockpit-navigator.sort", itemId);
+        localStorage.setItem("navigator:sort", itemId);
     };
 
     return (

--- a/src/navigator-folder-view.tsx
+++ b/src/navigator-folder-view.tsx
@@ -47,7 +47,7 @@ export const NavigatorFolderView = ({
 }) => {
     const [currentFilter, setCurrentFilter] = useState("");
     const [isGrid, setIsGrid] = useState(localStorage.getItem("navigator:isGrid") !== "false");
-    const [sortBy, setSortBy] = useState(localStorage.getItem("cockpit-navigator.sort") || "az");
+    const [sortBy, setSortBy] = useState(localStorage.getItem("navigator:sort") || "az");
     const onFilterChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => setCurrentFilter(value);
 
     return (

--- a/src/settings-dropdown.jsx
+++ b/src/settings-dropdown.jsx
@@ -39,7 +39,7 @@ export const SettingsDropdown = ({ showHidden, setShowHidden }) => {
 
     const onToggleHidden = () => {
         setShowHidden(prevShowHidden => {
-            localStorage.setItem("cockpit-navigator.showHiddenFiles", !showHidden ? "true" : "false");
+            localStorage.setItem("navigator:showHiddenFiles", !showHidden ? "true" : "false");
             return !prevShowHidden;
         });
     };

--- a/test/check-application
+++ b/test/check-application
@@ -140,8 +140,8 @@ class TestNavigator(testlib.MachineCase):
         self.browser.wait_js_cond("ph_count('#folder-view tbody tr') > 1")
 
         # Selected view is saved in localStorage
-        b.reload()
-        b.enter_page("/navigator")
+        b.logout()
+        self.enter_navigator()
         b.wait_visible("button[aria-label='Display as a grid']")
 
         # deleted files and directories are auto-detected


### PR DESCRIPTION
Cockpit cleans up all localStorage settings which are not prefixed with the application, the application name comes from the url itself where it is named "navigator", not "cockpit-navigator".