### PR TITLE
Show that the directory is empty

### DIFF
--- a/src/navigator-card-body.jsx
+++ b/src/navigator-card-body.jsx
@@ -32,6 +32,7 @@ import { FileIcon, FolderIcon } from "@patternfly/react-icons";
 import cockpit from "cockpit";
 import { useDialogs } from "dialogs.jsx";
 import { ListingTable } from "cockpit-components-table.jsx";
+import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 
 import { ContextMenu } from "cockpit-components-context-menu.jsx";
 import { fileActions } from "./fileActions.jsx";
@@ -347,6 +348,7 @@ export const NavigatorCardBody = ({
               id={navigator_parent_id}
               ref={folderViewRef}
             >
+                {sortedFiles.length === 0 && <EmptyStatePanel paragraph={_("Directory is empty")} />}
                 {isGrid &&
                     <CardBody id="navigator-card-body">
                         <Gallery id="folder-view">

--- a/test/check-application
+++ b/test/check-application
@@ -84,6 +84,9 @@ class TestNavigator(testlib.MachineCase):
         hidden_files_cnt = m.execute(r'ls -A /home/admin | grep "^\." | wc -l').strip()
         b.wait_text("#sidebar-card-header", f"admin{files_cnt} items ({hidden_files_cnt} hidden)")
 
+        # default directory is empty
+        b.wait_text(".pf-v5-c-empty-state__body", "Directory is empty")
+
         # new files are auto-detected
         m.execute("touch --date @1641038400 /home/admin/newfile")
         b.wait_visible("[data-item='newfile']")


### PR DESCRIPTION
When a directory is empty inform the user and reserve enough space for the contextmenu to still function.

Closes: #113

---

![image](https://github.com/cockpit-project/cockpit-navigator/assets/67428/e3c748e4-68fd-49c4-9d25-b266be81abc5)
