### PR TITLE
Ensure contextmenu is the child of it's parentId

### DIFF
--- a/src/navigator-card-body.jsx
+++ b/src/navigator-card-body.jsx
@@ -342,10 +342,9 @@ export const NavigatorCardBody = ({
     );
 
     return (
-        <>
+        <div id={navigator_parent_id}>
             {contextMenu}
             <div
-              id={navigator_parent_id}
               ref={folderViewRef}
             >
                 {sortedFiles.length === 0 && <EmptyStatePanel paragraph={_("Directory is empty")} />}
@@ -382,7 +381,7 @@ export const NavigatorCardBody = ({
                       }))}
                     />}
             </div>
-        </>
+        </div>
     );
 };
 


### PR DESCRIPTION
The contextmenu component's event listeners are installed on the DOM element with the id being `navigator_parent_id`. This should always be the parent of the contextMenu otherwise click events aren't handled by the ContextMenu component as the contextMenu is not a child in the DOM.

Moving the ContextMenu in the div with the cards causes the layout to change on a right click, which is unwanted.